### PR TITLE
feat: autolink without markdown format url

### DIFF
--- a/.cursor/rules/ephe.mdc
+++ b/.cursor/rules/ephe.mdc
@@ -1,15 +1,19 @@
 ---
 description: 
 globs: 
+alwaysApply: true
 ---
-
 ## General Rule
 
-- Write comments in English
-
+- Write comments in English.
+- Write performance code.
 
 ## TypeScript and React Rule
 
-- Use strict types
-- Use arrow functions
-- Write tests (vitest) with feature implementations
+- Use strict types.
+- Use camelCase for variable and function names.
+- Use PascalCase for component names.
+- Use double quotes for strings, use template literal if it's suitable.
+- Use arrow functions.
+- Use async/await for asynchronous code.
+- Use vitest to write tests.

--- a/src/features/monaco/editor-utils.tsx
+++ b/src/features/monaco/editor-utils.tsx
@@ -26,6 +26,8 @@ export const applyTaskCheckboxDecorations = (
   const decorations: monaco.editor.IModelDeltaDecoration[] = [];
   const lineCount = model.getLineCount();
 
+  // TODO: use getLinesContent()
+
   for (let lineNumber = 1; lineNumber <= lineCount; lineNumber++) {
     const lineContent = model.getLineContent(lineNumber);
 

--- a/src/monaco-markdown/errors.ts
+++ b/src/monaco-markdown/errors.ts
@@ -126,7 +126,7 @@ export type V8CallSite = {
   isNative(): boolean;
   isConstructor(): boolean;
   toString(): string;
-}
+};
 
 const canceledName = "Canceled";
 

--- a/src/monaco-markdown/formatting.ts
+++ b/src/monaco-markdown/formatting.ts
@@ -69,10 +69,6 @@ export const activateFormatting = (editor: TextEditor) => {
   // addKeybinding(editor, paste, [KeyMod.CtrlCmd | KeyCode.KEY_B], "Toggle bold");
 };
 
-/**
- * Here we store Regexp to check if the text is the single link.
- */
-const singleLinkRegex: RegExp = createLinkRegex();
 
 // Return Promise because need to chain operations in unit tests
 
@@ -348,6 +344,10 @@ const createLinkRegex = (): RegExp => {
 }
 
 /**
+ * Here we store Regexp to check if the text is the single link.
+ */
+const singleLinkRegex: RegExp = createLinkRegex();
+/**
  * Checks if the string is a link. The list of link examples you can see in the tests file
  * `test/linksRecognition.test.ts`. This code ported from django's
  * [URLValidator](https://github.com/django/django/blob/2.2b1/django/core/validators.py#L74) with some simplifyings.
@@ -356,7 +356,7 @@ const createLinkRegex = (): RegExp => {
  *
  * @return boolean
  */
-export function isSingleLink(text: string): boolean {
+export const isSingleLink = (text: string): boolean => {
   return singleLinkRegex.test(text);
 }
 

--- a/src/monaco-markdown/formatting.ts
+++ b/src/monaco-markdown/formatting.ts
@@ -342,7 +342,7 @@ function createLinkRegex(): RegExp {
     "\\.?"; // may have a trailing dot
 
   const host_re = `(${hostname_re}${domain_re}${tld_re}|localhost)`;
-  
+
   // Create two patterns - one with scheme and one without
   const withSchemePattern =
     "^(?:[a-z0-9\\.\\-\\+]*)://" + // scheme is not validated (in django it is validated additionally)

--- a/src/monaco-markdown/formatting.ts
+++ b/src/monaco-markdown/formatting.ts
@@ -321,7 +321,7 @@ function toggleListSingleLine(doc: TextDocument, line: number, wsEdit: Workspace
  *
  * @return Regexp
  */
-function createLinkRegex(): RegExp {
+const createLinkRegex = (): RegExp => {
   // unicode letters range(must not be a raw string)
   const ul = "\\u00a1-\\uffff";
   // IP patterns
@@ -333,32 +333,15 @@ function createLinkRegex(): RegExp {
   // Max length for domain name labels is 63 characters per RFC 1034 sec. 3.1
   const domain_re = `(?:\\.(?!-)[a-z${ul}0-9-]{1,63})*`;
 
-  const tld_re =
-    "\\." + // dot
-    "(?!-)" + // can't start with a dash
-    "(?:[a-z${ul}-]{2,63}" + // domain label
-    "|xn--[a-z0-9]{1,59})" + // or punycode label
-    // + '(?<!-)'                            // can't end with a dash
-    "\\.?"; // may have a trailing dot
+  const tld_re = `\\.((?!-)(?:[a-z${ul}-]{2,63}|xn--[a-z0-9]{1,59}))\\.?`; // dot, domain label/punycode, optional trailing dot
 
   const host_re = `(${hostname_re}${domain_re}${tld_re}|localhost)`;
 
   // Create two patterns - one with scheme and one without
-  const withSchemePattern =
-    "^(?:[a-z0-9\\.\\-\\+]*)://" + // scheme is not validated (in django it is validated additionally)
-    "(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?" + // user: pass authentication
-    "(?:${ipv4_re}|${ipv6_re}|${host_re})" +
-    "(?::\\d{2,5})?" + // port
-    "(?:[/?#][^\\s]*)?" + // resource path
-    "$"; // end of string
+  const withSchemePattern = `^(?:[a-z0-9\\.\\-\\+]*)://(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?(?:${ipv4_re}|${ipv6_re}|${host_re})(?::\\d{2,5})?(?:[/?#][^\\s]*)?$`;
 
   // Pattern for URLs without protocol (like example.com)
-  const withoutSchemePattern =
-    "^" +
-    "(?:${ipv4_re}|${host_re})" + // IP or hostname
-    "(?::\\d{2,5})?" + // port
-    "(?:[/?#][^\\s]*)?" + // resource path
-    "$"; // end of string
+  const withoutSchemePattern = `^(?:${ipv4_re}|${host_re})(?::\\d{2,5})?(?:[/?#][^\\s]*)?$`;
 
   // Combine both patterns with OR operator
   return new RegExp(`${withSchemePattern}|${withoutSchemePattern}`, "i");
@@ -377,7 +360,7 @@ export function isSingleLink(text: string): boolean {
   return singleLinkRegex.test(text);
 }
 
-function styleByWrapping(editor: TextEditor, startPattern: string, endPattern?: string) {
+const styleByWrapping = (editor: TextEditor, startPattern: string, endPattern?: string): PromiseLike<void> => {
   const actualEndPattern = endPattern === undefined ? startPattern : endPattern;
 
   const selections = editor.selections;
@@ -467,7 +450,7 @@ function styleByWrapping(editor: TextEditor, startPattern: string, endPattern?: 
  * @param startPtn
  * @param endPtn
  */
-function wrapRange(
+const wrapRange = (
   editor: TextEditor,
   wsEdit: WorkspaceEdit,
   shifts: [Position, number][],
@@ -479,7 +462,7 @@ function wrapRange(
   isSelected: boolean,
   startPtn: string,
   endPtn?: string,
-) {
+): void => {
   const actualEndPtn = endPtn === undefined ? startPtn : endPtn;
 
   const text = editor.document.getText(range);

--- a/src/monaco-markdown/formatting.ts
+++ b/src/monaco-markdown/formatting.ts
@@ -334,23 +334,34 @@ function createLinkRegex(): RegExp {
   const domain_re = `(?:\\.(?!-)[a-z${ul}0-9-]{1,63})*`;
 
   const tld_re =
-    `\\.` + // dot
-    `(?!-)` + // can't start with a dash
-    `(?:[a-z${ul}-]{2,63}` + // domain label
-    `|xn--[a-z0-9]{1,59})` + // or punycode label
+    "\\." + // dot
+    "(?!-)" + // can't start with a dash
+    "(?:[a-z${ul}-]{2,63}" + // domain label
+    "|xn--[a-z0-9]{1,59})" + // or punycode label
     // + '(?<!-)'                            // can't end with a dash
-    `\\.?`; // may have a trailing dot
+    "\\.?"; // may have a trailing dot
 
   const host_re = `(${hostname_re}${domain_re}${tld_re}|localhost)`;
-  const pattern =
-    `^(?:[a-z0-9\\.\\-\\+]*)://` + // scheme is not validated (in django it is validated additionally)
-    `(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?` + // user: pass authentication
-    `(?:${ipv4_re}|${ipv6_re}|${host_re})` +
-    `(?::\\d{2,5})?` + // port
-    `(?:[/?#][^\\s]*)?` + // resource path
-    `$`; // end of string
+  
+  // Create two patterns - one with scheme and one without
+  const withSchemePattern =
+    "^(?:[a-z0-9\\.\\-\\+]*)://" + // scheme is not validated (in django it is validated additionally)
+    "(?:[^\\s:@/]+(?::[^\\s:@/]*)?@)?" + // user: pass authentication
+    "(?:${ipv4_re}|${ipv6_re}|${host_re})" +
+    "(?::\\d{2,5})?" + // port
+    "(?:[/?#][^\\s]*)?" + // resource path
+    "$"; // end of string
 
-  return new RegExp(pattern, "i");
+  // Pattern for URLs without protocol (like example.com)
+  const withoutSchemePattern =
+    "^" +
+    "(?:${ipv4_re}|${host_re})" + // IP or hostname
+    "(?::\\d{2,5})?" + // port
+    "(?:[/?#][^\\s]*)?" + // resource path
+    "$"; // end of string
+
+  // Combine both patterns with OR operator
+  return new RegExp(`${withSchemePattern}|${withoutSchemePattern}`, "i");
 }
 
 /**

--- a/src/monaco-markdown/index.ts
+++ b/src/monaco-markdown/index.ts
@@ -49,8 +49,8 @@ export class MonacoMarkdownExtension {
 
     // Get the Monaco instance from the editor
     let monacoInstance: MonacoGlobal | undefined;
-    
-    if (typeof window !== 'undefined') {
+
+    if (typeof window !== "undefined") {
       const windowWithMonaco = window as unknown as { monaco?: MonacoGlobal };
       if (windowWithMonaco.monaco) {
         monacoInstance = windowWithMonaco.monaco;
@@ -58,94 +58,96 @@ export class MonacoMarkdownExtension {
     }
 
     if (!monacoInstance) {
-      console.error('Monaco instance not found');
+      console.error("Monaco instance not found");
       return;
     }
 
     // リンク種別判定関数
     const getLinkInfo = (text: string): { url: string; isMarkdown: boolean } => {
       // Markdownリンク[text](url)を検出
-      if (text.includes('](') && text.startsWith('[') && text.endsWith(')')) {
-        const closeBracketPos = text.lastIndexOf('](');
+      if (text.includes("](") && text.startsWith("[") && text.endsWith(")")) {
+        const closeBracketPos = text.lastIndexOf("](");
         if (closeBracketPos > 0) {
           const url = text.substring(closeBracketPos + 2, text.length - 1);
           return { url, isMarkdown: true };
         }
       }
-      
+
       // プロトコル付きURL
       if (protocolRegex.test(text)) {
         return { url: text, isMarkdown: false };
       }
-      
+
       // ドメインのみのURL
       if (domainRegex.test(text)) {
         return { url: `https://${text}`, isMarkdown: false };
       }
-      
+
       // フォールバック - プロトコルがないURLとして扱う
       return { url: `https://${text}`, isMarkdown: false };
     };
 
     // リンクプロバイダー登録
-    monacoInstance.languages.registerLinkProvider('markdown', {
+    monacoInstance.languages.registerLinkProvider("markdown", {
       provideLinks: (model: editor.ITextModel) => {
         const links: Array<{ range: IRange; url: string }> = [];
-        
+
         // 文書全体のテキストを取得
         const text = model.getValue();
-        const lines = text.split('\n');
-        
+        const lines = text.split("\n");
+
         // 効率的にリンクを検出（行ごとではなく一括で処理）
         for (let i = 0; i < lines.length; i++) {
           const lineContent = lines[i];
-          
+
           // リンクっぽい文字列が含まれていない行はスキップ（ただし、単純なドメインはチェック）
-          if (!lineContent.includes('://') && 
-              !lineContent.includes('.com') && 
-              !lineContent.includes('.org') && 
-              !lineContent.includes('.net') && 
-              !lineContent.includes('.io') && 
-              !lineContent.includes('.dev') && 
-              !lineContent.includes('.jp') && 
-              !lineContent.includes('.') && 
-              !lineContent.includes('[') && 
-              !lineContent.includes('](')) {
+          if (
+            !lineContent.includes("://") &&
+            !lineContent.includes(".com") &&
+            !lineContent.includes(".org") &&
+            !lineContent.includes(".net") &&
+            !lineContent.includes(".io") &&
+            !lineContent.includes(".dev") &&
+            !lineContent.includes(".jp") &&
+            !lineContent.includes(".") &&
+            !lineContent.includes("[") &&
+            !lineContent.includes("](")
+          ) {
             continue;
           }
-          
+
           // 単一のパスでリンクを検出
           const matches = lineContent.match(simpleLinkDetector);
           if (!matches) continue;
-          
+
           // 同じマッチが複数回出現する可能性を考慮して位置ベースで検出
           let remainingContent = lineContent;
           let currentOffset = 0;
-          
+
           for (const match of matches) {
             const matchIndex = remainingContent.indexOf(match);
             if (matchIndex === -1) continue;
-            
+
             const absoluteIndex = currentOffset + matchIndex;
             const startColumn = absoluteIndex + 1;
             const endColumn = startColumn + match.length;
-            
+
             // リンク種別に応じてURLを取得
             const { url, isMarkdown } = getLinkInfo(match);
-            
+
             // Markdownリンクの場合、URL部分だけを範囲としてマーク
             if (isMarkdown) {
-              const closePos = match.lastIndexOf('](');
+              const closePos = match.lastIndexOf("](");
               const urlStartPos = closePos + 2;
-              
+
               links.push({
                 range: {
                   startLineNumber: i + 1,
                   startColumn: startColumn + urlStartPos,
                   endLineNumber: i + 1,
-                  endColumn: endColumn - 1  // 閉じ括弧を除く
+                  endColumn: endColumn - 1, // 閉じ括弧を除く
                 },
-                url
+                url,
               });
             } else {
               links.push({
@@ -153,20 +155,20 @@ export class MonacoMarkdownExtension {
                   startLineNumber: i + 1,
                   startColumn,
                   endLineNumber: i + 1,
-                  endColumn
+                  endColumn,
                 },
-                url
+                url,
               });
             }
-            
+
             // 処理済みの部分をスキップして次のマッチを探す
             remainingContent = remainingContent.substring(matchIndex + match.length);
             currentOffset += matchIndex + match.length;
           }
         }
-        
+
         return { links };
-      }
+      },
     });
   }
 }

--- a/src/monaco-markdown/index.ts
+++ b/src/monaco-markdown/index.ts
@@ -1,4 +1,5 @@
 import { editor } from "monaco-editor";
+import type { IRange, languages } from "monaco-editor";
 import { activateFormatting } from "./formatting";
 import { setWordDefinitionFor, TextEditor } from "./vscode-monaco";
 import { activateListEditing } from "./listEditing";
@@ -7,7 +8,14 @@ import { activateTableFormatter } from "./tableFormatter";
 
 import { activateMarkdownMath } from "./markdown.contribution";
 
+// Define a type for the Monaco global object
+interface MonacoGlobal {
+  languages: typeof languages;
+}
+
 export class MonacoMarkdownExtension {
+  private isLinkProviderRegistered = false;
+
   activate(editor: editor.IStandaloneCodeEditor) {
     const textEditor = new TextEditor(editor);
 
@@ -15,12 +23,151 @@ export class MonacoMarkdownExtension {
     activateListEditing(textEditor);
     activateCompletion(textEditor);
     activateTableFormatter(textEditor);
+    this.registerLinkProvider(editor);
 
     // Allow `*` in word pattern for quick styling
     setWordDefinitionFor(
       textEditor.languageId,
-      /(-?\d*\.\d\w*)|([^\!\@\#\%\^\&\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s\，\。\《\》\？\；\：\‘\“\’\”\（\）\【\】\、]+)/g,
+      /(-?\d*\.\d\w*)|([^\!\@\#\%\^\&\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s\，\。\《\》\？\；\：\'\"\'\"\（\）\【\】\、]+)/g,
     );
+  }
+
+  /**
+   * Register a link provider for Markdown links
+   * @param editor The Monaco editor instance
+   */
+  private registerLinkProvider(editor: editor.IStandaloneCodeEditor) {
+    if (this.isLinkProviderRegistered) return;
+    this.isLinkProviderRegistered = true;
+
+    // ミニマムな正規表現定義 - 極力シンプルにする
+    const simpleLinkDetector = /https?:\/\/\S+|\b[a-z0-9][a-z0-9-]*\.[a-z]{2,}(?:\/\S*)?\b|\[[^\]]+\]\([^)]+\)/gi;
+
+    // リンク判定のための補助正規表現
+    const protocolRegex = /^https?:\/\//;
+    const domainRegex = /^[a-z0-9][a-z0-9-]*\.[a-z]{2,}/i;
+
+    // Get the Monaco instance from the editor
+    let monacoInstance: MonacoGlobal | undefined;
+    
+    if (typeof window !== 'undefined') {
+      const windowWithMonaco = window as unknown as { monaco?: MonacoGlobal };
+      if (windowWithMonaco.monaco) {
+        monacoInstance = windowWithMonaco.monaco;
+      }
+    }
+
+    if (!monacoInstance) {
+      console.error('Monaco instance not found');
+      return;
+    }
+
+    // リンク種別判定関数
+    const getLinkInfo = (text: string): { url: string; isMarkdown: boolean } => {
+      // Markdownリンク[text](url)を検出
+      if (text.includes('](') && text.startsWith('[') && text.endsWith(')')) {
+        const closeBracketPos = text.lastIndexOf('](');
+        if (closeBracketPos > 0) {
+          const url = text.substring(closeBracketPos + 2, text.length - 1);
+          return { url, isMarkdown: true };
+        }
+      }
+      
+      // プロトコル付きURL
+      if (protocolRegex.test(text)) {
+        return { url: text, isMarkdown: false };
+      }
+      
+      // ドメインのみのURL
+      if (domainRegex.test(text)) {
+        return { url: `https://${text}`, isMarkdown: false };
+      }
+      
+      // フォールバック - プロトコルがないURLとして扱う
+      return { url: `https://${text}`, isMarkdown: false };
+    };
+
+    // リンクプロバイダー登録
+    monacoInstance.languages.registerLinkProvider('markdown', {
+      provideLinks: (model: editor.ITextModel) => {
+        const links: Array<{ range: IRange; url: string }> = [];
+        
+        // 文書全体のテキストを取得
+        const text = model.getValue();
+        const lines = text.split('\n');
+        
+        // 効率的にリンクを検出（行ごとではなく一括で処理）
+        for (let i = 0; i < lines.length; i++) {
+          const lineContent = lines[i];
+          
+          // リンクっぽい文字列が含まれていない行はスキップ（ただし、単純なドメインはチェック）
+          if (!lineContent.includes('://') && 
+              !lineContent.includes('.com') && 
+              !lineContent.includes('.org') && 
+              !lineContent.includes('.net') && 
+              !lineContent.includes('.io') && 
+              !lineContent.includes('.dev') && 
+              !lineContent.includes('.jp') && 
+              !lineContent.includes('.') && 
+              !lineContent.includes('[') && 
+              !lineContent.includes('](')) {
+            continue;
+          }
+          
+          // 単一のパスでリンクを検出
+          const matches = lineContent.match(simpleLinkDetector);
+          if (!matches) continue;
+          
+          // 同じマッチが複数回出現する可能性を考慮して位置ベースで検出
+          let remainingContent = lineContent;
+          let currentOffset = 0;
+          
+          for (const match of matches) {
+            const matchIndex = remainingContent.indexOf(match);
+            if (matchIndex === -1) continue;
+            
+            const absoluteIndex = currentOffset + matchIndex;
+            const startColumn = absoluteIndex + 1;
+            const endColumn = startColumn + match.length;
+            
+            // リンク種別に応じてURLを取得
+            const { url, isMarkdown } = getLinkInfo(match);
+            
+            // Markdownリンクの場合、URL部分だけを範囲としてマーク
+            if (isMarkdown) {
+              const closePos = match.lastIndexOf('](');
+              const urlStartPos = closePos + 2;
+              
+              links.push({
+                range: {
+                  startLineNumber: i + 1,
+                  startColumn: startColumn + urlStartPos,
+                  endLineNumber: i + 1,
+                  endColumn: endColumn - 1  // 閉じ括弧を除く
+                },
+                url
+              });
+            } else {
+              links.push({
+                range: {
+                  startLineNumber: i + 1,
+                  startColumn,
+                  endLineNumber: i + 1,
+                  endColumn
+                },
+                url
+              });
+            }
+            
+            // 処理済みの部分をスキップして次のマッチを探す
+            remainingContent = remainingContent.substring(matchIndex + match.length);
+            currentOffset += matchIndex + match.length;
+          }
+        }
+        
+        return { links };
+      }
+    });
   }
 }
 

--- a/src/monaco-markdown/index.ts
+++ b/src/monaco-markdown/index.ts
@@ -13,9 +13,11 @@ interface MonacoGlobal {
   languages: typeof languages;
 }
 
-export class MonacoMarkdownExtension {
-  private isLinkProviderRegistered = false;
+const simpleLinkDetector = /https?:\/\/\S+|\b[a-z0-9][a-z0-9-]*\.[a-z]{2,}(?:\/\S*)?\b|\[[^\]]+\]\([^)]+\)/gi;
+const protocolRegex = /^https?:\/\//;
+const domainRegex = /^[a-z0-9][a-z0-9-]*\.[a-z]{2,}/i;
 
+export class MonacoMarkdownExtension {
   activate(editor: editor.IStandaloneCodeEditor) {
     const textEditor = new TextEditor(editor);
 
@@ -23,7 +25,7 @@ export class MonacoMarkdownExtension {
     activateListEditing(textEditor);
     activateCompletion(textEditor);
     activateTableFormatter(textEditor);
-    this.registerLinkProvider(editor);
+    this.registerLinkProvider();
 
     // Allow `*` in word pattern for quick styling
     setWordDefinitionFor(
@@ -34,18 +36,8 @@ export class MonacoMarkdownExtension {
 
   /**
    * Register a link provider for Markdown links
-   * @param editor The Monaco editor instance
    */
-  private registerLinkProvider(editor: editor.IStandaloneCodeEditor) {
-    if (this.isLinkProviderRegistered) return;
-    this.isLinkProviderRegistered = true;
-
-    // ミニマムな正規表現定義 - 極力シンプルにする
-    const simpleLinkDetector = /https?:\/\/\S+|\b[a-z0-9][a-z0-9-]*\.[a-z]{2,}(?:\/\S*)?\b|\[[^\]]+\]\([^)]+\)/gi;
-
-    // リンク判定のための補助正規表現
-    const protocolRegex = /^https?:\/\//;
-    const domainRegex = /^[a-z0-9][a-z0-9-]*\.[a-z]{2,}/i;
+  private registerLinkProvider() {
 
     // Get the Monaco instance from the editor
     let monacoInstance: MonacoGlobal | undefined;

--- a/src/monaco-markdown/markdown.ts
+++ b/src/monaco-markdown/markdown.ts
@@ -117,12 +117,15 @@ export const language = <languages.IMonarchLanguage>{
       [/\{+[^}]+\}+/, "string.target"],
       [/(!?\[)((?:[^\]\\]|@escapes)*)(\]\([^\)]+\))/, ["string.link", "", "string.link"]],
       [/(!?\[)((?:[^\]\\]|@escapes)*)(\])/, "string.link"],
-      
+
       // NOTE(@unvalley): Added for usability
       // Auto-link URLs with protocols (e.g., http://example.com) - simple and efficient regex
       [/\b(?:https?|ftp):\/\/\S+/, "string.link"],
       // Auto-link URLs without protocols (e.g., example.com) - simple and efficient regex
-      [/\b(?:[a-z0-9][-a-z0-9]*\.)+(?:com|org|net|edu|gov|mil|io|dev|co|jp|us|app|so|ai|design|info|shop|de|ru|br|uk|is|it|fr|de)\b/i, "string.link"],
+      [
+        /\b(?:[a-z0-9][-a-z0-9]*\.)+(?:com|org|net|edu|gov|mil|io|dev|co|jp|us|app|so|ai|design|info|shop|de|ru|br|uk|is|it|fr|de)\b/i,
+        "string.link",
+      ],
 
       //inline math
       [

--- a/src/monaco-markdown/markdown.ts
+++ b/src/monaco-markdown/markdown.ts
@@ -117,6 +117,12 @@ export const language = <languages.IMonarchLanguage>{
       [/\{+[^}]+\}+/, "string.target"],
       [/(!?\[)((?:[^\]\\]|@escapes)*)(\]\([^\)]+\))/, ["string.link", "", "string.link"]],
       [/(!?\[)((?:[^\]\\]|@escapes)*)(\])/, "string.link"],
+      
+      // NOTE(@unvalley): Added for usability
+      // Auto-link URLs with protocols (e.g., http://example.com) - simple and efficient regex
+      [/\b(?:https?|ftp):\/\/\S+/, "string.link"],
+      // Auto-link URLs without protocols (e.g., example.com) - simple and efficient regex
+      [/\b(?:[a-z0-9][-a-z0-9]*\.)+(?:com|org|net|edu|gov|mil|io|dev|co|jp|us|app|so|ai|design|info|shop|de|ru|br|uk|is|it|fr|de)\b/i, "string.link"],
 
       //inline math
       [

--- a/src/monaco-markdown/vscode-common.ts
+++ b/src/monaco-markdown/vscode-common.ts
@@ -38,4 +38,4 @@ export type TextLine = {
    * for [TextLine.firstNonWhitespaceCharacterIndex](#TextLine.firstNonWhitespaceCharacterIndex) === [TextLine.text.length](#TextLine.text).
    */
   readonly isEmptyOrWhitespace: boolean;
-}
+};

--- a/src/page/history-page.tsx
+++ b/src/page/history-page.tsx
@@ -406,7 +406,9 @@ export const HistoryPage = () => {
                   <option value="">All Months</option>
                   {availableMonths.map((month) => (
                     <option key={month} value={month}>
-                      {new Date(2000, month - 1, 1).toLocaleString("default", { month: "long" })}
+                      {new Date(2000, month - 1, 1).toLocaleString("default", {
+                        month: "long",
+                      })}
                     </option>
                   ))}
                 </select>


### PR DESCRIPTION
Make url to link without markdown syntax.

![Screenshot 2025-03-26 at 22 55 04](https://github.com/user-attachments/assets/eec59645-41a6-4cfc-9849-277b4a756aee)


- Before: `[example.com](https://example.com)`
- After: `example.com`

yes of course you can use the before way. it's the markdown syntax.

actually low quality code again🤣