### PR TITLE
chore: remove unused css and dead code

### DIFF
--- a/src/features/editor/multi/dock-menu.tsx
+++ b/src/features/editor/multi/dock-menu.tsx
@@ -1,6 +1,6 @@
 import { useAtom } from "jotai";
 import { activeDocumentIndexAtom, documentsAtom } from "../../../utils/atoms/multi-document";
-import { useCallback, useMemo, useRef, useState, type DragEvent } from "react";
+import { useCallback, useRef, useState, type DragEvent } from "react";
 import { motion } from "motion/react";
 
 const SPRING_CONFIG = {
@@ -63,13 +63,6 @@ export const getCardButtonClasses = (isActive: boolean, isDockHovered: boolean):
       : "bg-gray-100 dark:bg-gray-600";
 
   return `${baseClasses} ${shapeClasses} ${stateClasses}`;
-};
-
-const useCardStyles = (total: number, hoveredIndex: number | null, dockActive: boolean) => {
-  return useMemo(
-    () => Array.from({ length: total }, (_, index) => calculateCardStyle(index, total, hoveredIndex, dockActive)),
-    [total, hoveredIndex, dockActive],
-  );
 };
 
 type DockDragState = {
@@ -142,9 +135,11 @@ export const DocumentDock = ({ onNavigate }: DocumentDockProps) => {
   const { dockActive, handleDockMouseLeave, handleDragEnd, handleDragStart, isDragging, dockState, setDockState } =
     useDockDragState();
 
-  const documentPreviews = useMemo(() => documents.map((doc) => generatePreviewContent(doc.content)), [documents]);
+  const documentPreviews = documents.map((doc) => generatePreviewContent(doc.content));
   const hoveredIndexForStyle = isDragging ? null : dockState.hoveredIndex;
-  const cardStyles = useCardStyles(documents.length, hoveredIndexForStyle, dockActive);
+  const cardStyles = Array.from({ length: documents.length }, (_, index) =>
+    calculateCardStyle(index, documents.length, hoveredIndexForStyle, dockActive),
+  );
 
   const handleDrop = useCallback(
     (targetIndex: number) => {

--- a/src/features/editor/table-of-contents.tsx
+++ b/src/features/editor/table-of-contents.tsx
@@ -75,15 +75,18 @@ export const TableOfContents: React.FC<TocProps> = ({ content, onItemClick, isVi
         {tocItems.map((item) => (
           <li
             key={item.line}
-            className={`cursor-pointer whitespace-normal break-words rounded px-2 py-1 hover:bg-neutral-100 dark:hover:bg-neutral-800 ${isDarkMode ? "text-neutral-400 hover:text-neutral-200" : "text-neutral-500 hover:text-neutral-800"}`}
             style={{
               paddingLeft: `${(item.level - 1) * 0.75 + 0.5}rem`,
               lineHeight: 1.3,
             }}
-            onClick={() => onItemClick(item.line)}
-            onKeyDown={() => {}}
           >
-            {item.text}
+            <button
+              type="button"
+              className={`w-full cursor-pointer whitespace-normal break-words rounded px-2 py-1 text-left hover:bg-neutral-100 dark:hover:bg-neutral-800 ${isDarkMode ? "text-neutral-400 hover:text-neutral-200" : "text-neutral-500 hover:text-neutral-800"}`}
+              onClick={() => onItemClick(item.line)}
+            >
+              {item.text}
+            </button>
           </li>
         ))}
       </ul>

--- a/src/globals.css
+++ b/src/globals.css
@@ -93,7 +93,7 @@ body {
   background-color: white;
   border: none;
   outline: none;
-  border-radius: var(--radius-md);
+  border-radius: 0.375rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
   padding: 6px 8px;
   font-size: 12px;

--- a/src/utils/hooks/use-paper-mode.ts
+++ b/src/utils/hooks/use-paper-mode.ts
@@ -23,24 +23,9 @@ export const usePaperMode = () => {
     return modes[nextIndex];
   };
 
-  const toggleNormalMode = () => {
-    setPaperMode((prev) => (prev === "normal" ? "normal" : "normal"));
-  };
-
-  const toggleGraphMode = () => {
-    setPaperMode((prev) => (prev === "graph" ? "normal" : "graph"));
-  };
-
-  const toggleDotsMode = () => {
-    setPaperMode((prev) => (prev === "dots" ? "normal" : "dots"));
-  };
-
   return {
     paperMode,
     paperModeClass: PAPER_MODE_CLASSES[paperMode],
     cyclePaperMode,
-    toggleNormalMode,
-    toggleGraphMode,
-    toggleDotsMode,
   };
 };

--- a/src/utils/hooks/use-user-activity.ts
+++ b/src/utils/hooks/use-user-activity.ts
@@ -63,11 +63,8 @@ export const useUserActivity = (options: UseUserActivityOptions = {}) => {
     };
   }, []);
 
-  const isActive = isTyping || isScrolling;
-
   return {
-    isActive,
-    isHidden: isActive,
+    isHidden: isTyping || isScrolling,
     isTyping,
     isScrolling,
   };


### PR DESCRIPTION
## Summary
- Delete dead code and unused CSS found via a repo-wide audit
- Verified locally: `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm test` (21 passed; browser tests skipped due to missing Playwright Chromium binary, unrelated), and dev server (`pnpm dev`) serves edited modules with HTTP 200 and no Vite errors

### Changes
- `src/globals.css`: replace undefined `var(--radius-md)` with `0.375rem`
- `src/utils/hooks/use-paper-mode.ts`: drop 3 unused `toggle*` exports (`toggleNormalMode` included a no-op ternary)
- `src/utils/hooks/use-user-activity.ts`: drop duplicate `isActive` return (only `isHidden` is consumed)
- `src/features/editor/table-of-contents.tsx`: replace `<li onClick onKeyDown={()=>{}}>` with a real `<button>` so keyboard a11y actually works
- `src/features/editor/multi/dock-menu.tsx`: inline the `useCardStyles` `useMemo` wrapper (React Compiler is enabled per CLAUDE.md)

### Not touched (need product-side judgment)
- `dock-menu.tsx:60` `dark:bg-gray-100` — possibly intentional
- `use-command-k.ts:30-34` secondary effect — may still be load-bearing depending on modal interaction

## Test plan
- [x] `pnpm lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm test` (unit tests pass)
- [x] `pnpm dev` loads without errors
- [ ] Manual smoke test: paper mode cycle, ToC click + keyboard, dock drag/reorder, footer auto-hide on typing