### PR TITLE
fix: UI/a11y polish (size-N, prefers-reduced-motion)

### DIFF
--- a/src/features/menu/system-menu.tsx
+++ b/src/features/menu/system-menu.tsx
@@ -128,7 +128,7 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
                 <div className="px-3 py-2 text-primary-400 text-xs dark:text-primary-300">Document Stats</div>
                 <MenuItem disabled>
                   <div className="flex items-center px-4 py-2.5 text-sm data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-900/30">
-                    <span className="mr-3 flex h-5 w-5 items-center justify-center">
+                    <span className="mr-3 flex size-5 items-center justify-center">
                       <HashIcon className="size-4" weight="light" />
                     </span>
                     <span>{charCount > 0 ? `${charCount.toLocaleString()} chars` : "No content"}</span>
@@ -137,7 +137,7 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
 
                 <MenuItem disabled>
                   <div className="flex items-center px-4 py-2.5 text-sm data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-900/30">
-                    <span className="mr-3 flex h-5 w-5 items-center justify-center">
+                    <span className="mr-3 flex size-5 items-center justify-center">
                       <HashIcon className="size-4" weight="light" />
                     </span>
                     <span>{wordCount > 0 ? `${wordCount.toLocaleString()} words` : "No content"}</span>
@@ -150,7 +150,7 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
                     className="flex w-full items-center px-4 py-2.5 text-sm hover:bg-neutral-50 data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-900/30 dark:hover:bg-neutral-700/70"
                     onClick={() => openTaskSnapshotModal(0)}
                   >
-                    <span className="mr-3 flex h-5 w-5 items-center justify-center">
+                    <span className="mr-3 flex size-5 items-center justify-center">
                       {todayCompletedTasks > 0 ? (
                         <CheckCircleIcon className="size-4 text-green-600" weight="light" />
                       ) : (
@@ -169,7 +169,7 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
                     className="flex w-full items-center px-4 py-2.5 text-sm hover:bg-neutral-50 data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-900/30 dark:hover:bg-neutral-700/70"
                     onClick={() => openTaskSnapshotModal(1)}
                   >
-                    <span className="mr-3 flex h-5 w-5 items-center justify-center">
+                    <span className="mr-3 flex size-5 items-center justify-center">
                       <FloppyDiskIcon className="size-4" weight="light" />
                     </span>
                     <span>{snapshotCount > 0 ? `${snapshotCount} snapshots` : "No snapshots"}</span>
@@ -194,7 +194,7 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
                     }}
                     className="flex w-full items-center px-4 py-2.5 text-left text-sm transition-colors duration-150 hover:bg-neutral-50 data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-900/30 dark:hover:bg-neutral-700/70"
                   >
-                    <span className="mr-3 flex h-5 w-5 items-center justify-center">
+                    <span className="mr-3 flex size-5 items-center justify-center">
                       {theme === COLOR_THEME.LIGHT ? (
                         <SunIcon className="size-4" weight="light" />
                       ) : theme === COLOR_THEME.DARK ? (
@@ -213,7 +213,7 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
                     onClick={cyclePaperMode}
                     className="flex w-full items-center px-4 py-2.5 text-left text-sm transition-colors duration-150 hover:bg-neutral-50 data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-900/30 dark:hover:bg-neutral-700/70"
                   >
-                    <span className="mr-3 flex h-5 w-5 items-center justify-center">
+                    <span className="mr-3 flex size-5 items-center justify-center">
                       <NotebookIcon className="size-4" weight="light" />
                     </span>
                     <span className="capitalize">{paperMode} Paper</span>
@@ -227,7 +227,7 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
                     }}
                     className="flex w-full items-center px-4 py-2.5 text-left text-sm transition-colors duration-150 hover:bg-neutral-50 data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-900/30 dark:hover:bg-neutral-700/70"
                   >
-                    <span className="mr-3 flex h-5 w-5 items-center justify-center">
+                    <span className="mr-3 flex size-5 items-center justify-center">
                       <ArrowsHorizontalIcon className="size-4" weight="light" />
                     </span>
                     <span className="capitalize">{editorWidth} Width</span>
@@ -245,7 +245,7 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
                     }}
                     className="flex w-full items-center px-4 py-2.5 text-left text-sm transition-colors duration-150 hover:bg-neutral-50 data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-900/30 dark:hover:bg-neutral-700/70"
                   >
-                    <span className="mr-3 flex h-5 w-5 items-center justify-center">
+                    <span className="mr-3 flex size-5 items-center justify-center">
                       <TextAaIcon className="size-4" weight="light" />
                     </span>
                     <span className="capitalize">{currentFontDisplayValue}</span>
@@ -257,7 +257,7 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
                     onClick={toggleEditorMode}
                     className="flex w-full items-center px-4 py-2.5 text-left text-sm transition-colors duration-150 hover:bg-neutral-50 data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-900/30 dark:hover:bg-neutral-700/70"
                   >
-                    <span className="mr-3 flex h-5 w-5 items-center justify-center">
+                    <span className="mr-3 flex size-5 items-center justify-center">
                       <SquaresFourIcon className="size-4" weight="light" />
                     </span>
                     <span className="capitalize">{editorMode} Editor</span>
@@ -275,7 +275,7 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
                     }}
                     className="flex w-full items-center px-4 py-2.5 text-left text-sm transition-colors duration-150 hover:bg-neutral-50 data-[focus]:bg-primary-50 dark:data-[focus]:bg-primary-900/30 dark:hover:bg-neutral-700/70"
                   >
-                    <span className="mr-3 flex h-5 w-5 items-center justify-center">
+                    <span className="mr-3 flex size-5 items-center justify-center">
                       <LightningIcon className={"size-4"} weight="light" />
                     </span>
                     <span className={"capitalize"}>Task Flush: {taskAutoFlushMode}</span>

--- a/src/globals.css
+++ b/src/globals.css
@@ -10,6 +10,20 @@
   }
 }
 
+/* WCAG 2.3.3 — collapse animations for users who prefer reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    /* biome-ignore-start lint/complexity/noImportantStyles: a11y override must beat library/inline styles */
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+    /* biome-ignore-end lint/complexity/noImportantStyles: a11y override must beat library/inline styles */
+  }
+}
+
 body {
   font-family: "Inter", "Noto Sans JP", sans-serif;
 }

--- a/src/utils/components/loading.tsx
+++ b/src/utils/components/loading.tsx
@@ -5,7 +5,7 @@ type LoadingProps = {
 export const Loading = ({ className }: LoadingProps) => {
   return (
     <div className={className}>
-      <div className="h-4 w-4 animate-ping rounded-full bg-neutral-300 dark:bg-neutral-100" />
+      <div className="size-4 animate-ping rounded-full bg-neutral-300 dark:bg-neutral-100" />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Collapse `w-N h-N` Tailwind pairs to the `size-N` shorthand (square icons in `system-menu` and `loading`).
- Add a global `@media (prefers-reduced-motion: reduce)` block in `globals.css` so animations and transitions collapse for users who request reduced motion (WCAG 2.3.3).

Part 1 of 3 splitting the react-doctor cleanup (score 89 → 96).

## Test plan
- [ ] `pnpm lint`
- [ ] `pnpm build`
- [ ] Visual check: icons in System menu and the loading spinner render unchanged.
- [ ] Toggle OS "Reduce motion" and confirm modal/menu animations are flattened.