### PR TITLE
perf: Intl.Segmenter hoist, lighter blur

### DIFF
--- a/src/features/editor/multi/document-navigation.tsx
+++ b/src/features/editor/multi/document-navigation.tsx
@@ -27,10 +27,10 @@ const NavigationCard = ({ direction, isVisible, onClick }: NavigationCardProps) 
       <button
         type="button"
         onClick={onClick}
-        className="group relative flex h-16 w-16 items-center justify-center rounded-xl bg-white shadow-xl transition-all duration-400 ease-out hover:scale-110 hover:bg-primary-50 hover:shadow-2xl dark:border-gray-700 dark:bg-primary-700 dark:hover:bg-primary-750"
+        className="group relative flex size-16 items-center justify-center rounded-xl bg-white shadow-xl transition-all duration-400 ease-out hover:scale-110 hover:bg-primary-50 hover:shadow-2xl dark:border-gray-700 dark:bg-primary-700 dark:hover:bg-primary-750"
         style={{
-          backdropFilter: "blur(20px)",
-          WebkitBackdropFilter: "blur(20px)",
+          backdropFilter: "blur(8px)",
+          WebkitBackdropFilter: "blur(8px)",
         }}
       >
         <div className="text-primary-600 transition-colors duration-300 group-hover:text-primary-800 dark:text-primary-400 dark:group-hover:text-primary-200">

--- a/src/features/time-display/hours-display.tsx
+++ b/src/features/time-display/hours-display.tsx
@@ -74,8 +74,8 @@ export const HoursDisplay = () => {
           maxHeight: "650px",
           overflow: "hidden",
           transform: "translateX(-30%)",
-          backdropFilter: "blur(20px)",
-          WebkitBackdropFilter: "blur(20px)",
+          backdropFilter: "blur(8px)",
+          WebkitBackdropFilter: "blur(8px)",
         }}
         onMouseLeave={() => setShowTooltip(false)}
       >

--- a/src/utils/hooks/use-word-count.ts
+++ b/src/utils/hooks/use-word-count.ts
@@ -25,36 +25,45 @@ export const useWordCount = () => {
   return { wordCount };
 };
 
+const JAPANESE_CHAR_RE = /[\u4E00-\u9FFF\u3040-\u309F\u30A0-\u30FF]/;
+
+// Cache one Intl.Segmenter per locale. Constructing one allocates dozens of
+// objects, so reusing across calls matters for typing-rate hot paths.
+const segmenterCache = new Map<string, Intl.Segmenter | null>();
+const getSegmenter = (locale: "ja" | "en"): Intl.Segmenter | null => {
+  if (typeof Intl === "undefined" || !("Segmenter" in Intl)) return null;
+  const cached = segmenterCache.get(locale);
+  if (cached !== undefined) return cached;
+  try {
+    const segmenter = new Intl.Segmenter(locale, { granularity: "word" });
+    segmenterCache.set(locale, segmenter);
+    return segmenter;
+  } catch {
+    segmenterCache.set(locale, null);
+    return null;
+  }
+};
+
 export const countWords = (text: string): number => {
   if (!text || text.trim().length === 0) {
     return 0;
   }
 
-  // Use Intl.Segmenter if available
-  // Note: It may over-segment Japanese text, but it's still better than nothing
-  if (typeof Intl !== "undefined" && "Segmenter" in Intl) {
-    try {
-      // Detect if text contains Japanese characters
-      const hasJapanese = /[\u4E00-\u9FFF\u3040-\u309F\u30A0-\u30FF]/.test(text);
-
-      // Use appropriate locale: 'ja' for Japanese content, 'en' for others
-      const locale = hasJapanese ? "ja" : "en";
-      const segmenter = new Intl.Segmenter(locale, { granularity: "word" });
-      const segments = segmenter.segment(text);
-
-      let wordCount = 0;
-      for (const segment of segments) {
-        if (segment.isWordLike) {
-          wordCount++;
-        }
+  // Use Intl.Segmenter if available. It may over-segment Japanese, but is still
+  // better than the regex fallback.
+  const locale = JAPANESE_CHAR_RE.test(text) ? "ja" : "en";
+  const segmenter = getSegmenter(locale);
+  if (segmenter) {
+    let wordCount = 0;
+    for (const segment of segmenter.segment(text)) {
+      if (segment.isWordLike) {
+        wordCount++;
       }
-      return wordCount;
-    } catch (_e) {
-      // Fall through to regex approach
     }
+    return wordCount;
   }
 
-  // Fallback: Count English words and Japanese character groups
+  // Fallback: count English words and Japanese character groups separately.
   const englishWords = text.match(/\b[a-zA-Z0-9]+\b/g) || [];
   const japaneseGroups = text.match(/[\u4E00-\u9FFF\u3040-\u309F\u30A0-\u30FF]+/g) || [];
 


### PR DESCRIPTION
## Summary
- Hoist `Intl.Segmenter` out of `countWords` and cache one instance per locale. Constructing a `Segmenter` allocates dozens of objects; this matters on the typing hot path that drives the word counter.
- Drop `backdropFilter: blur(20px)` to `blur(8px)` in `HoursDisplay` and the document-navigation overlay. React-doctor flagged large blurs because cost scales with radius × layer size and can blow GPU memory on mobile.

Part 2 of 3 splitting the react-doctor cleanup (score 89 → 96).

## Test plan
- [ ] `pnpm test` (word-count unit tests cover JA/EN paths)
- [ ] `pnpm build`
- [ ] Visual check on `HoursDisplay` tooltip and the document navigation peek — still looks frosted, just cheaper.