### PR TITLE
refactor: history modal, command menu, motion

### DIFF
--- a/src/features/editor/multi/dock-menu.tsx
+++ b/src/features/editor/multi/dock-menu.tsx
@@ -1,7 +1,7 @@
 import { useAtom } from "jotai";
 import { activeDocumentIndexAtom, documentsAtom } from "../../../utils/atoms/multi-document";
 import { useCallback, useRef, useState, type DragEvent } from "react";
-import { motion } from "motion/react";
+import { m } from "motion/react";
 
 const SPRING_CONFIG = {
   stiffness: 180,
@@ -203,7 +203,7 @@ export const DocumentDock = ({ onNavigate }: DocumentDockProps) => {
                   : 0;
 
           return (
-            <motion.div
+            <m.div
               key={doc.id}
               className="absolute"
               animate={{
@@ -266,7 +266,7 @@ export const DocumentDock = ({ onNavigate }: DocumentDockProps) => {
                   </div>
                 )}
               </button>
-            </motion.div>
+            </m.div>
           );
         })}
       </nav>

--- a/src/features/editor/multi/multi-editor.tsx
+++ b/src/features/editor/multi/multi-editor.tsx
@@ -5,7 +5,7 @@ import { useRef, useEffect, useImperativeHandle, useCallback } from "react";
 import { DocumentNavigation } from "./document-navigation";
 import { MultiDocumentProvider } from "./multi-context";
 import type { SingleEditorRef, MultiEditorRef } from "../editor-ref";
-import { motion, AnimatePresence } from "motion/react";
+import { AnimatePresence, m } from "motion/react";
 
 type MultiDocumentEditorProps = {
   ref?: React.Ref<MultiEditorRef>;
@@ -104,7 +104,7 @@ export const MultiDocumentEditor = ({ ref }: MultiDocumentEditorProps) => {
   return (
     <div className="relative h-full w-full overflow-hidden">
       <AnimatePresence mode="wait">
-        <motion.div
+        <m.div
           key={documents[activeIndex].id}
           className="h-full w-full"
           initial={{ opacity: 0 }}
@@ -118,7 +118,7 @@ export const MultiDocumentEditor = ({ ref }: MultiDocumentEditorProps) => {
             documentId={documents[activeIndex].id}
             onChange={saveDocument}
           />
-        </motion.div>
+        </m.div>
       </AnimatePresence>
 
       <MultiDocumentProvider navigateToDocument={navigateToDocument}>

--- a/src/features/history/history-modal.tsx
+++ b/src/features/history/history-modal.tsx
@@ -54,7 +54,6 @@ const BUTTON_STYLES = {
 } as const;
 
 export const HistoryModal = ({ isOpen, onClose, initialTabIndex = 0 }: HistoryModalProps) => {
-  const [selectedTabIndex, setSelectedTabIndex] = useState(initialTabIndex);
   const [selectedSnapshot, setSelectedSnapshot] = useState<Snapshot | null>(null);
   const {
     snapshots,
@@ -67,10 +66,6 @@ export const HistoryModal = ({ isOpen, onClose, initialTabIndex = 0 }: HistoryMo
     handleDeleteAllTasks,
     refresh,
   } = useHistoryData();
-
-  useEffect(() => {
-    setSelectedTabIndex(initialTabIndex);
-  }, [initialTabIndex]);
 
   useEffect(() => {
     if (isOpen) {
@@ -159,8 +154,8 @@ export const HistoryModal = ({ isOpen, onClose, initialTabIndex = 0 }: HistoryMo
             >
               <DialogPanel className="w-full max-w-5xl transform overflow-hidden rounded-md bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-neutral-800">
                 <div className="mt-4">
-                  <TabGroup selectedIndex={selectedTabIndex} onChange={setSelectedTabIndex}>
-                    <TabList className="flex space-x-1">
+                  <TabGroup key={initialTabIndex} defaultIndex={initialTabIndex}>
+                    <TabList className="flex gap-x-1">
                       <Tab
                         className={({ selected }) =>
                           `rounded-md px-2 py-1 transition-colors ${selected ? "" : "text-neutral-300 dark:text-neutral-500"}`
@@ -190,7 +185,7 @@ export const HistoryModal = ({ isOpen, onClose, initialTabIndex = 0 }: HistoryMo
                           {isLoading ? (
                             <div className="flex h-full items-center justify-center">
                               <div className="py-10 text-center text-neutral-500 dark:text-neutral-400">
-                                Loading tasks...
+                                Loading tasks…
                               </div>
                             </div>
                           ) : tasks.length > 0 ? (
@@ -259,14 +254,14 @@ export const HistoryModal = ({ isOpen, onClose, initialTabIndex = 0 }: HistoryMo
                             ) : isLoading ? (
                               <div className="flex h-full items-center justify-center">
                                 <div className="text-center text-neutral-500 dark:text-neutral-400">
-                                  Loading snapshots...
+                                  Loading snapshots…
                                 </div>
                               </div>
                             ) : selectedSnapshot ? (
                               <div className="flex h-full flex-col">
                                 <div className="mb-4 flex items-center justify-between">
                                   <h4 className="text-md">{formatDate(selectedSnapshot.timestamp)}</h4>
-                                  <div className="flex space-x-2">
+                                  <div className="flex gap-x-2">
                                     <button type="button" onClick={handleRestore} className={BUTTON_STYLES.primary}>
                                       Restore
                                     </button>
@@ -298,7 +293,7 @@ export const HistoryModal = ({ isOpen, onClose, initialTabIndex = 0 }: HistoryMo
                             <div className="w-1/4 overflow-y-auto pl-4">
                               {isLoading ? (
                                 <div className="py-10 text-center text-neutral-500 dark:text-neutral-400">
-                                  Loading...
+                                  Loading…
                                 </div>
                               ) : (
                                 <div className="divide-y divide-neutral-200 dark:divide-neutral-600">

--- a/src/features/menu/command-menu.tsx
+++ b/src/features/menu/command-menu.tsx
@@ -65,6 +65,17 @@ type CommandItem = {
   perform: () => void;
 };
 
+const INTERFACE_IDS = new Set(["theme-toggle", "paper-mode", "editor-width", "font-family"]);
+const OPERATION_IDS = new Set([
+  "export-markdown",
+  "format-document",
+  "insert-github-issues",
+  "open-tasks",
+  "open-snapshots",
+  "save-snapshot",
+]);
+const NAVIGATION_IDS = new Set(["github-repo", "history"]);
+
 export const CommandMenu = ({
   open,
   onClose = () => {},
@@ -87,6 +98,9 @@ export const CommandMenu = ({
       setInputValue("");
       return;
     }
+    // Focus the input after the menu mounts. Replaces the autoFocus attribute,
+    // which trips jsx-a11y/no-autofocus.
+    const raf = requestAnimationFrame(() => inputRef.current?.focus());
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault();
@@ -99,7 +113,10 @@ export const CommandMenu = ({
       }
     };
     document.addEventListener("keydown", handleKeyDown, true); // Use capture phase
-    return () => document.removeEventListener("keydown", handleKeyDown, true);
+    return () => {
+      cancelAnimationFrame(raf);
+      document.removeEventListener("keydown", handleKeyDown, true);
+    };
   }, [open, onClose]);
 
   const cyclePaperModeThenClose = () => {
@@ -409,7 +426,6 @@ export const CommandMenu = ({
                 onValueChange={setInputValue}
                 placeholder="Type a command or search..."
                 className="w-full border-none bg-transparent py-2.5 pr-3 pl-9 text-neutral-900 text-sm outline-none placeholder:text-neutral-400 focus:ring-0 dark:text-neutral-100 dark:placeholder:text-neutral-500" // focus:ring-0 でフォーカス時のリングを消去
-                autoFocus
               />
             </div>
 
@@ -425,111 +441,108 @@ export const CommandMenu = ({
                 heading="Interface"
                 className="mb-1 px-1 font-medium text-neutral-500 text-xs tracking-wider dark:text-neutral-400"
               >
-                {commandsList()
-                  .filter((cmd) => ["theme-toggle", "paper-mode", "editor-width", "font-family"].includes(cmd.id))
-                  .map((command) => (
-                    <Command.Item
-                      key={command.id}
-                      value={command.name}
-                      onSelect={command.perform}
-                      className="group mt-1 flex cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-1.5 text-neutral-900 text-sm transition-colors hover:bg-neutral-100 aria-selected:bg-primary-500/10 aria-selected:text-primary-600 dark:text-neutral-100 dark:aria-selected:bg-primary-500/20 dark:aria-selected:text-primary-400 dark:hover:bg-zinc-800"
-                    >
-                      <div className="flex items-center gap-2">
-                        <div className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md bg-neutral-100/80 text-neutral-900 transition-colors group-hover:bg-neutral-200 group-aria-selected:bg-primary-500/20 dark:bg-zinc-700/60 dark:text-neutral-100 dark:group-aria-selected:bg-primary-600/20 dark:group-hover:bg-zinc-600">
-                          {command.icon}
-                        </div>
-                        <span className="flex-grow truncate">
-                          {" "}
-                          {command.name}
-                          {command.id === "paper-mode" && currentPaperMode && (
-                            <span className="ml-1.5 text-neutral-500 text-xs dark:text-neutral-400">
-                              ({currentPaperMode})
+                {commandsList().flatMap((command) =>
+                  INTERFACE_IDS.has(command.id)
+                    ? [
+                        <Command.Item
+                          key={command.id}
+                          value={command.name}
+                          onSelect={command.perform}
+                          className="group mt-1 flex cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-1.5 text-neutral-900 text-sm transition-colors hover:bg-neutral-100 aria-selected:bg-primary-500/10 aria-selected:text-primary-600 dark:text-neutral-100 dark:aria-selected:bg-primary-500/20 dark:aria-selected:text-primary-400 dark:hover:bg-zinc-800"
+                        >
+                          <div className="flex items-center gap-2">
+                            <div className="flex size-5 flex-shrink-0 items-center justify-center rounded-md bg-neutral-100/80 text-neutral-900 transition-colors group-hover:bg-neutral-200 group-aria-selected:bg-primary-500/20 dark:bg-zinc-700/60 dark:text-neutral-100 dark:group-aria-selected:bg-primary-600/20 dark:group-hover:bg-zinc-600">
+                              {command.icon}
+                            </div>
+                            <span className="flex-grow truncate">
+                              {" "}
+                              {command.name}
+                              {command.id === "paper-mode" && currentPaperMode && (
+                                <span className="ml-1.5 text-neutral-500 text-xs dark:text-neutral-400">
+                                  ({currentPaperMode})
+                                </span>
+                              )}
+                              {command.id === "editor-width" && currentEditorWidth && (
+                                <span className="ml-1.5 text-neutral-500 text-xs dark:text-neutral-400">
+                                  ({currentEditorWidth})
+                                </span>
+                              )}
+                              {command.id === "font-family" && (
+                                <span className="ml-1.5 text-neutral-500 text-xs dark:text-neutral-400">
+                                  ({FONT_FAMILIES[fontFamily].displayValue})
+                                </span>
+                              )}
                             </span>
+                          </div>
+                          {command.shortcut && (
+                            <kbd className="hidden flex-shrink-0 select-none rounded border border-neutral-200 bg-neutral-50 px-1.5 py-0.5 font-medium text-neutral-500 text-xs group-hover:border-neutral-300 sm:inline-block dark:border-zinc-700 dark:bg-zinc-800 dark:text-neutral-400">
+                              {command.shortcut}
+                            </kbd>
                           )}
-                          {command.id === "editor-width" && currentEditorWidth && (
-                            <span className="ml-1.5 text-neutral-500 text-xs dark:text-neutral-400">
-                              ({currentEditorWidth})
-                            </span>
-                          )}
-                          {command.id === "font-family" && (
-                            <span className="ml-1.5 text-neutral-500 text-xs dark:text-neutral-400">
-                              ({FONT_FAMILIES[fontFamily].displayValue})
-                            </span>
-                          )}
-                        </span>
-                      </div>
-                      {command.shortcut && (
-                        <kbd className="hidden flex-shrink-0 select-none rounded border border-neutral-200 bg-neutral-50 px-1.5 py-0.5 font-medium text-neutral-500 text-xs group-hover:border-neutral-300 sm:inline-block dark:border-zinc-700 dark:bg-zinc-800 dark:text-neutral-400">
-                          {command.shortcut}
-                        </kbd>
-                      )}
-                    </Command.Item>
-                  ))}
+                        </Command.Item>,
+                      ]
+                    : [],
+                )}
               </Command.Group>
 
               <Command.Group
                 heading="Operations"
                 className="mb-1 px-1 font-medium text-neutral-500 text-xs tracking-wider dark:text-neutral-400"
               >
-                {commandsList()
-                  .filter((cmd) =>
-                    [
-                      "export-markdown",
-                      "format-document",
-                      "insert-github-issues",
-                      "open-tasks",
-                      "open-snapshots",
-                      "save-snapshot",
-                    ].includes(cmd.id),
-                  )
-                  .map((command) => (
-                    <Command.Item
-                      key={command.id}
-                      value={command.name}
-                      onSelect={command.perform}
-                      className="group mt-1 flex cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-1.5 text-neutral-900 text-sm transition-colors hover:bg-neutral-100 aria-selected:bg-primary-500/10 aria-selected:text-primary-600 dark:text-neutral-100 dark:aria-selected:bg-primary-500/20 dark:aria-selected:text-primary-400 dark:hover:bg-zinc-800"
-                    >
-                      <div className="flex items-center gap-2">
-                        <div className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md bg-neutral-100/80 text-neutral-900 transition-colors group-hover:bg-neutral-200 group-aria-selected:bg-primary-500/20 dark:bg-zinc-700/60 dark:text-neutral-100 dark:group-aria-selected:bg-primary-600/20 dark:group-hover:bg-zinc-600">
-                          {command.icon}
-                        </div>
-                        <span className="flex-grow truncate">{command.name}</span>
-                      </div>
-                      {command.shortcut && (
-                        <kbd className="hidden flex-shrink-0 select-none rounded border border-neutral-200 bg-neutral-50 px-1.5 py-0.5 font-medium text-neutral-500 text-xs group-hover:border-neutral-300 sm:inline-block dark:border-zinc-700 dark:bg-zinc-800 dark:text-neutral-400">
-                          {command.shortcut}
-                        </kbd>
-                      )}
-                    </Command.Item>
-                  ))}
+                {commandsList().flatMap((command) =>
+                  OPERATION_IDS.has(command.id)
+                    ? [
+                        <Command.Item
+                          key={command.id}
+                          value={command.name}
+                          onSelect={command.perform}
+                          className="group mt-1 flex cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-1.5 text-neutral-900 text-sm transition-colors hover:bg-neutral-100 aria-selected:bg-primary-500/10 aria-selected:text-primary-600 dark:text-neutral-100 dark:aria-selected:bg-primary-500/20 dark:aria-selected:text-primary-400 dark:hover:bg-zinc-800"
+                        >
+                          <div className="flex items-center gap-2">
+                            <div className="flex size-5 flex-shrink-0 items-center justify-center rounded-md bg-neutral-100/80 text-neutral-900 transition-colors group-hover:bg-neutral-200 group-aria-selected:bg-primary-500/20 dark:bg-zinc-700/60 dark:text-neutral-100 dark:group-aria-selected:bg-primary-600/20 dark:group-hover:bg-zinc-600">
+                              {command.icon}
+                            </div>
+                            <span className="flex-grow truncate">{command.name}</span>
+                          </div>
+                          {command.shortcut && (
+                            <kbd className="hidden flex-shrink-0 select-none rounded border border-neutral-200 bg-neutral-50 px-1.5 py-0.5 font-medium text-neutral-500 text-xs group-hover:border-neutral-300 sm:inline-block dark:border-zinc-700 dark:bg-zinc-800 dark:text-neutral-400">
+                              {command.shortcut}
+                            </kbd>
+                          )}
+                        </Command.Item>,
+                      ]
+                    : [],
+                )}
               </Command.Group>
 
               <Command.Group
                 heading="Navigation"
                 className="mb-1 px-1 font-medium text-neutral-500 text-xs tracking-wider dark:text-neutral-400"
               >
-                {commandsList()
-                  .filter((cmd) => ["github-repo", "history"].includes(cmd.id))
-                  .map((command) => (
-                    <Command.Item
-                      key={command.id}
-                      value={command.name}
-                      onSelect={command.perform}
-                      className="group mt-1 flex cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-1.5 text-neutral-900 text-sm transition-colors hover:bg-neutral-100 aria-selected:bg-primary-500/10 aria-selected:text-primary-600 dark:text-neutral-100 dark:aria-selected:bg-primary-500/20 dark:aria-selected:text-primary-400 dark:hover:bg-zinc-800"
-                    >
-                      <div className="flex items-center gap-2">
-                        <div className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md bg-neutral-100/80 text-neutral-900 transition-colors group-hover:bg-neutral-200 group-aria-selected:bg-primary-500/20 dark:bg-zinc-700/60 dark:text-neutral-100 dark:group-aria-selected:bg-primary-600/20 dark:group-hover:bg-zinc-600">
-                          {command.icon}
-                        </div>
-                        <span className="flex-grow truncate">{command.name}</span>
-                      </div>
-                      {command.shortcut && (
-                        <kbd className="hidden flex-shrink-0 select-none rounded border border-neutral-200 bg-neutral-50 px-1.5 py-0.5 font-medium text-neutral-500 text-xs group-hover:border-neutral-300 sm:inline-block dark:border-zinc-700 dark:bg-zinc-800 dark:text-neutral-400">
-                          {command.shortcut}
-                        </kbd>
-                      )}
-                    </Command.Item>
-                  ))}
+                {commandsList().flatMap((command) =>
+                  NAVIGATION_IDS.has(command.id)
+                    ? [
+                        <Command.Item
+                          key={command.id}
+                          value={command.name}
+                          onSelect={command.perform}
+                          className="group mt-1 flex cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-1.5 text-neutral-900 text-sm transition-colors hover:bg-neutral-100 aria-selected:bg-primary-500/10 aria-selected:text-primary-600 dark:text-neutral-100 dark:aria-selected:bg-primary-500/20 dark:aria-selected:text-primary-400 dark:hover:bg-zinc-800"
+                        >
+                          <div className="flex items-center gap-2">
+                            <div className="flex size-5 flex-shrink-0 items-center justify-center rounded-md bg-neutral-100/80 text-neutral-900 transition-colors group-hover:bg-neutral-200 group-aria-selected:bg-primary-500/20 dark:bg-zinc-700/60 dark:text-neutral-100 dark:group-aria-selected:bg-primary-600/20 dark:group-hover:bg-zinc-600">
+                              {command.icon}
+                            </div>
+                            <span className="flex-grow truncate">{command.name}</span>
+                          </div>
+                          {command.shortcut && (
+                            <kbd className="hidden flex-shrink-0 select-none rounded border border-neutral-200 bg-neutral-50 px-1.5 py-0.5 font-medium text-neutral-500 text-xs group-hover:border-neutral-300 sm:inline-block dark:border-zinc-700 dark:bg-zinc-800 dark:text-neutral-400">
+                              {command.shortcut}
+                            </kbd>
+                          )}
+                        </Command.Item>,
+                      ]
+                    : [],
+                )}
               </Command.Group>
             </Command.List>
 

--- a/src/page/editor-page.tsx
+++ b/src/page/editor-page.tsx
@@ -1,4 +1,5 @@
 import "../globals.css";
+import { LazyMotion, domAnimation } from "motion/react";
 import { usePaperMode } from "../utils/hooks/use-paper-mode";
 import { Footer, FooterButton } from "../utils/components/footer";
 import { CommandMenu } from "../features/menu/command-menu";
@@ -68,54 +69,56 @@ export const EditorPage = () => {
   };
 
   return (
-    <div className={`flex h-screen flex-col overflow-hidden antialiased ${paperModeClass}`}>
-      <div className="relative flex flex-1 overflow-hidden">
-        <div className="z-0 flex-1">
-          {editorMode === "multi" ? (
-            <MultiDocumentEditor ref={multiEditorRef} />
-          ) : (
-            <CodeMirrorEditor ref={singleEditorRef} />
-          )}
+    <LazyMotion features={domAnimation} strict>
+      <div className={`flex h-screen flex-col overflow-hidden antialiased ${paperModeClass}`}>
+        <div className="relative flex flex-1 overflow-hidden">
+          <div className="z-0 flex-1">
+            {editorMode === "multi" ? (
+              <MultiDocumentEditor ref={multiEditorRef} />
+            ) : (
+              <CodeMirrorEditor ref={singleEditorRef} />
+            )}
+          </div>
         </div>
+
+        <Footer
+          autoHide={true}
+          leftContent={<SystemMenu onOpenHistoryModal={openHistoryModal} />}
+          centerContent={
+            isMobile || editorMode === "single" ? null : (
+              <DocumentDock onNavigate={(index) => multiEditorRef.current?.navigateToDocument(index)} />
+            )
+          }
+          rightContent={
+            <>
+              <HoursDisplay />
+              <FooterButton>
+                <Link to="/landing">Ephe v{EPHE_VERSION}</Link>
+              </FooterButton>
+            </>
+          }
+        />
+        <CommandMenu
+          aria-modal="true"
+          open={isCommandMenuOpen}
+          onClose={handleCommandMenuClose}
+          editorContent={
+            editorMode === "multi"
+              ? (multiEditorRef.current?.getCurrentContent() ?? "")
+              : (singleEditorRef.current?.getCurrentContent() ?? editorContent)
+          }
+          editorView={
+            editorMode === "multi" ? (multiEditorRef.current?.view ?? null) : (singleEditorRef.current?.view ?? null)
+          }
+          onOpenHistoryModal={openHistoryModal}
+        />
+
+        <HistoryModal
+          isOpen={historyModalOpen}
+          onClose={() => setHistoryModalOpen(false)}
+          initialTabIndex={historyModalTabIndex}
+        />
       </div>
-
-      <Footer
-        autoHide={true}
-        leftContent={<SystemMenu onOpenHistoryModal={openHistoryModal} />}
-        centerContent={
-          isMobile || editorMode === "single" ? null : (
-            <DocumentDock onNavigate={(index) => multiEditorRef.current?.navigateToDocument(index)} />
-          )
-        }
-        rightContent={
-          <>
-            <HoursDisplay />
-            <FooterButton>
-              <Link to="/landing">Ephe v{EPHE_VERSION}</Link>
-            </FooterButton>
-          </>
-        }
-      />
-      <CommandMenu
-        aria-modal="true"
-        open={isCommandMenuOpen}
-        onClose={handleCommandMenuClose}
-        editorContent={
-          editorMode === "multi"
-            ? (multiEditorRef.current?.getCurrentContent() ?? "")
-            : (singleEditorRef.current?.getCurrentContent() ?? editorContent)
-        }
-        editorView={
-          editorMode === "multi" ? (multiEditorRef.current?.view ?? null) : (singleEditorRef.current?.view ?? null)
-        }
-        onOpenHistoryModal={openHistoryModal}
-      />
-
-      <HistoryModal
-        isOpen={historyModalOpen}
-        onClose={() => setHistoryModalOpen(false)}
-        initialTabIndex={historyModalTabIndex}
-      />
-    </div>
+    </LazyMotion>
   );
 };


### PR DESCRIPTION
## Summary
- **history-modal**: switch `TabGroup` to uncontrolled (`defaultIndex` + `key` reset) and remove the mirrored `useState`/`useEffect` for `initialTabIndex`. Also: typographic ellipsis (…) for loading labels, and `space-x-*` → `gap-x-*` on flex parents.
- **command-menu**: remove `autoFocus` from the cmdk input (jsx-a11y/no-autofocus) and focus via `requestAnimationFrame` on open. Replace three `.filter().map()` chains with `.flatMap()` over module-scope `Set` lookups. Adopt `size-N` shorthand for icon containers.
- **motion**: wrap `EditorPage` in `<LazyMotion features={domAnimation} strict>` and swap `motion.div` for `m.div` in `multi-editor` and `dock-menu`. Saves ~30kb from the initial bundle by lazy-loading DOM animation features.

Part 3 of 3 splitting the react-doctor cleanup (score 89 → 96).

## Test plan
- [ ] `pnpm test` (145 unit tests)
- [ ] `pnpm test:e2e`
- [ ] `pnpm build` — verify bundle size shrinks for the entry chunk.
- [ ] Open command menu (⌘K) → input is focused; ⌘K / Esc closes.
- [ ] Open History modal from both the System menu (Tasks/Snapshots entries) and the command menu — correct tab is selected each time.
- [ ] Switch documents in multi-editor mode — fade transition still works.
- [ ] Hover the document dock — card spring animation still works.