### PR TITLE
feat: add configurable cursor colors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: pnpm/action-setup@v3
         with:
           version: ${{ env.PNPM_VERSION }}
-          run_install: true
 
       - uses: actions/setup-node@v4
         with:
@@ -57,7 +56,6 @@ jobs:
       - uses: pnpm/action-setup@v3
         with:
           version: ${{ env.PNPM_VERSION }}
-          run_install: true
 
       - uses: actions/setup-node@v4
         with:
@@ -87,7 +85,6 @@ jobs:
       - uses: pnpm/action-setup@v3
         with:
           version: ${{ env.PNPM_VERSION }}
-          run_install: true
 
       - uses: actions/setup-node@v4
         with:
@@ -108,9 +105,19 @@ jobs:
           key: ${{ env.CACHE_KEY_PREFIX }}-${{ runner.os }}-vitest-${{ hashFiles('**/*.ts', '**/*.tsx') }}
           restore-keys: |
             ${{ env.CACHE_KEY_PREFIX }}-${{ runner.os }}-vitest-
+
+      - name: Restore Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ env.CACHE_KEY_PREFIX }}-${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ env.CACHE_KEY_PREFIX }}-${{ runner.os }}-playwright-
     
       - name: Install Playwright Browsers
-        run: npx playwright install chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install chromium
 
       - name: Run Vitest
         run: pnpm test

--- a/src/features/editor/codemirror/use-editor-theme.ts
+++ b/src/features/editor/codemirror/use-editor-theme.ts
@@ -2,14 +2,16 @@ import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { EditorView } from "@codemirror/view";
 import { tags } from "@lezer/highlight";
 import { useMemo } from "react";
+import { getCursorColor, type CursorColor } from "../../../utils/hooks/use-cursor-color";
 
 /**
  * Manages the CodeMirror theme and highlight style based on dark mode, editor width, and font family.
  */
-export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFamily: string) => {
+export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFamily: string, cursorColor: CursorColor) => {
   return useMemo(() => {
     const COLORS = isDarkMode ? EPHE_COLORS.dark : EPHE_COLORS.light;
     const CODE_SYNTAX_HIGHLIGHT = isDarkMode ? SYNTAX_HIGHLIGHT_STYLES.dark : SYNTAX_HIGHLIGHT_STYLES.light;
+    const CURSOR = getCursorColor(cursorColor);
 
     const epheHighlightStyle = HighlightStyle.define([
       ...CODE_SYNTAX_HIGHLIGHT,
@@ -52,13 +54,35 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
         lineHeight: "1.6",
         maxWidth: isWideMode ? "100%" : "680px",
         margin: "0 auto",
-        caretColor: COLORS.foreground,
+        caretColor: "transparent",
         fontFeatureSettings: fontFamily.includes("Mynerve") ? '"calt" off, "salt" off' : "normal",
         fontVariantLigatures: fontFamily.includes("Mynerve") ? "none" : "normal",
       },
       ".cm-cursor": {
-        borderLeftColor: COLORS.foreground,
-        borderLeftWidth: "2px",
+        borderLeft: "none",
+        width: "2.5px",
+        height: "1.8em !important",
+        marginTop: "-0.28em",
+        borderRadius: "2px",
+        backgroundColor: isDarkMode ? CURSOR.valueDark : CURSOR.valueLight,
+        transition: "transform 80ms ease",
+      },
+      ".cm-cursorLayer": {
+        animationDuration: "1.2s !important",
+        animationTimingFunction: "ease-in-out !important",
+      },
+      "@keyframes cm-blink": {
+        "0%, 18%": { opacity: 1 },
+        "50%": { opacity: 0 },
+        "82%, 100%": { opacity: 1 },
+      },
+      "@keyframes cm-blink2": {
+        "0%, 18%": { opacity: 1 },
+        "50%": { opacity: 0 },
+        "82%, 100%": { opacity: 1 },
+      },
+      ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
+        backgroundColor: isDarkMode ? CURSOR.selectionDark : CURSOR.selectionLight,
       },
       "&.cm-editor": {
         outline: "none",
@@ -92,7 +116,7 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
       editorTheme: EditorView.theme(theme),
       editorHighlightStyle: syntaxHighlighting(epheHighlightStyle, { fallback: true }),
     };
-  }, [isDarkMode, isWideMode, fontFamily]);
+  }, [isDarkMode, isWideMode, fontFamily, cursorColor]);
 };
 
 const EPHE_COLORS = {

--- a/src/features/editor/codemirror/use-markdown-editor.ts
+++ b/src/features/editor/codemirror/use-markdown-editor.ts
@@ -2,7 +2,7 @@ import { defaultKeymap, historyKeymap, history } from "@codemirror/commands";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { languages } from "@codemirror/language-data";
 import { Compartment, EditorState, Prec } from "@codemirror/state";
-import { EditorView, keymap, placeholder } from "@codemirror/view";
+import { EditorView, drawSelection, keymap, placeholder } from "@codemirror/view";
 import { useAtom, useAtomValue } from "jotai";
 import { useRef, useEffect, useLayoutEffect, useState } from "react";
 import { showToast } from "../../../utils/components/toast";
@@ -21,6 +21,7 @@ import { urlClickPlugin, urlHoverTooltip } from "./url-click";
 import { useDebouncedCallback } from "use-debounce";
 import { editorContentAtom } from "../../../utils/atoms/editor";
 import { currentFontValueAtom } from "../../../utils/hooks/use-font";
+import { cursorColorAtom, resolveCursorColor } from "../../../utils/hooks/use-cursor-color";
 
 const useMarkdownFormatter = () => {
   const ref = useRef<DprintMarkdownFormatter | null>(null);
@@ -77,8 +78,9 @@ export const useMarkdownEditor = (
   const { isDarkMode } = useTheme();
   const { isWideMode } = useEditorWidth();
   const currentFontValue = useAtomValue(currentFontValueAtom);
+  const cursorColor = resolveCursorColor(useAtomValue(cursorColorAtom));
 
-  const { editorTheme, editorHighlightStyle } = useEditorTheme(isDarkMode, isWideMode, currentFontValue);
+  const { editorTheme, editorHighlightStyle } = useEditorTheme(isDarkMode, isWideMode, currentFontValue, cursorColor);
   const { isMobile } = useMobileDetector();
 
   const themeCompartment = useRef(new Compartment()).current;
@@ -201,6 +203,7 @@ export const useMarkdownEditor = (
         }),
 
         EditorView.lineWrapping,
+        drawSelection(),
         EditorView.updateListener.of((update) => {
           if (update.docChanged) {
             // Skip updates from programmatic changes (formatting, restore, etc.)

--- a/src/features/menu/system-menu.tsx
+++ b/src/features/menu/system-menu.tsx
@@ -196,10 +196,8 @@ const CursorColorControl = ({
           aria-label={color.label}
           aria-pressed={active}
           className={cx(
-            "flex size-7 items-center justify-center rounded transition-[background-color,color,transform,box-shadow] duration-150 ease-out hover:scale-[1.03] focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 active:scale-95 dark:focus-visible:ring-neutral-600",
-            active
-              ? "bg-neutral-200 text-neutral-950 dark:bg-white/20 dark:text-neutral-50"
-              : "hover:bg-white/80 hover:text-neutral-900 dark:hover:bg-white/10 dark:hover:text-neutral-50",
+            "flex size-7 items-center justify-center rounded transition-[background-color,transform,box-shadow] duration-150 ease-out hover:scale-[1.03] focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 active:scale-95 dark:focus-visible:ring-neutral-600",
+            active ? "bg-neutral-200 dark:bg-white/20" : "hover:bg-white/80 dark:hover:bg-white/10",
           )}
           onClick={(event) => {
             event.stopPropagation();

--- a/src/features/menu/system-menu.tsx
+++ b/src/features/menu/system-menu.tsx
@@ -6,6 +6,7 @@ import { useEditorWidth, type EditorWidth } from "../../utils/hooks/use-editor-w
 import { useCharCount } from "../../utils/hooks/use-char-count";
 import { useWordCount } from "../../utils/hooks/use-word-count";
 import { FONT_FAMILY_OPTIONS, fontFamilyAtom, currentFontDisplayValueAtom } from "../../utils/hooks/use-font";
+import { CURSOR_COLORS, CURSOR_COLOR_OPTIONS, useCursorColor, type CursorColor } from "../../utils/hooks/use-cursor-color";
 import { useEditorMode, type EditorMode } from "../../utils/hooks/use-editor-mode";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
@@ -171,16 +172,61 @@ const SegmentedControl = <T extends string>({
   </span>
 );
 
+const CursorColorControl = ({
+  value,
+  isDarkMode,
+  onChange,
+}: {
+  value: CursorColor;
+  isDarkMode: boolean;
+  onChange: (value: CursorColor) => void;
+}) => (
+  <span
+    className="inline-flex h-8 shrink-0 items-center gap-0.5 rounded-md bg-neutral-100 p-0.5 dark:bg-white/10"
+    title="Cursor color"
+  >
+    {CURSOR_COLOR_OPTIONS.map((option) => {
+      const active = option === value;
+      const color = CURSOR_COLORS[option];
+
+      return (
+        <button
+          type="button"
+          key={option}
+          aria-label={color.label}
+          aria-pressed={active}
+          className={cx(
+            "flex size-7 items-center justify-center rounded transition-[background-color,color,transform,box-shadow] duration-150 ease-out hover:scale-[1.03] focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 active:scale-95 dark:focus-visible:ring-neutral-600",
+            active
+              ? "bg-neutral-200 text-neutral-950 dark:bg-white/20 dark:text-neutral-50"
+              : "hover:bg-white/80 hover:text-neutral-900 dark:hover:bg-white/10 dark:hover:text-neutral-50",
+          )}
+          onClick={(event) => {
+            event.stopPropagation();
+            onChange(option);
+          }}
+        >
+          <span
+            className="size-3.5 rounded-full border border-black/10 dark:border-white/20"
+            style={{ backgroundColor: isDarkMode ? color.valueDark : color.valueLight }}
+          />
+        </button>
+      );
+    })}
+  </span>
+);
+
 export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, isDarkMode } = useTheme();
   const { paperMode, setPaperMode } = usePaperMode();
   const [fontFamily, setFontFamily] = useAtom(fontFamilyAtom);
   const currentFontDisplayValue = useAtomValue(currentFontDisplayValueAtom);
   const { editorMode, setSingleMode, setMultiMode } = useEditorMode();
   const { editorWidth, setNormalWidth, setWideWidth } = useEditorWidth();
+  const { cursorColor, setCursorColor } = useCursorColor();
   const { charCount } = useCharCount();
   const { wordCount } = useWordCount();
   const { todayCompletedTasks } = useTodayCompletedTasks(menuOpen);
@@ -300,6 +346,9 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
               <ActionMenuRow label="Font" onClick={cycleFont} icon={<TextAaIcon className="size-5" weight="regular" />}>
                 <ValuePill>{currentFontDisplayValue}</ValuePill>
               </ActionMenuRow>
+              <StaticMenuRow label="Cursor">
+                <CursorColorControl value={cursorColor} isDarkMode={isDarkMode} onChange={setCursorColor} />
+              </StaticMenuRow>
               <StaticMenuRow label="Editor">
                 <SegmentedControl
                   ariaLabel="Editor mode"

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,6 +9,7 @@ export const LOCAL_STORAGE_KEYS = {
   TOC_MODE: "ephe:toc-mode",
   TASK_AUTO_FLUSH_MODE: "ephe:task-auto-flush-mode",
   FONT_FAMILY: "ephe:font-family",
+  CURSOR_COLOR: "ephe:cursor-color",
   CURSOR_POSITION: "ephe:cursor-position",
   DOCUMENTS: "ephe:documents",
   ACTIVE_DOCUMENT_INDEX: "ephe:active-document-index",

--- a/src/utils/hooks/use-cursor-color.ts
+++ b/src/utils/hooks/use-cursor-color.ts
@@ -7,7 +7,6 @@ export const CURSOR_COLORS = {
     label: "Ink",
     valueLight: "#262626",
     valueDark: "#D4D4D4",
-    swatch: "#262626",
     selectionLight: "rgba(38, 38, 38, 0.16)",
     selectionDark: "rgba(212, 212, 212, 0.22)",
   },
@@ -15,7 +14,6 @@ export const CURSOR_COLORS = {
     label: "Cyan",
     valueLight: "#00C1FA",
     valueDark: "#00C1FA",
-    swatch: "#00C1FA",
     selectionLight: "rgba(0, 52, 73, 0.24)",
     selectionDark: "rgba(0, 52, 73, 1)",
   },
@@ -29,8 +27,10 @@ type StoredCursorColor = CursorColor | "gray" | "amber";
 
 export const cursorColorAtom = atomWithStorage<StoredCursorColor>(LOCAL_STORAGE_KEYS.CURSOR_COLOR, "ink");
 
-export const resolveCursorColor = (cursorColor: StoredCursorColor): CursorColor =>
-  cursorColor in CURSOR_COLORS ? (cursorColor as CursorColor) : "ink";
+export const resolveCursorColor = (cursorColor: StoredCursorColor): CursorColor => {
+  if (cursorColor === "cyan") return "cyan";
+  return "ink";
+};
 
 export const getCursorColor = (cursorColor: StoredCursorColor) => CURSOR_COLORS[resolveCursorColor(cursorColor)];
 
@@ -40,7 +40,6 @@ export const useCursorColor = () => {
 
   return {
     cursorColor: resolvedCursorColor,
-    cursorColorValue: getCursorColor(resolvedCursorColor).swatch,
     setCursorColor,
   };
 };

--- a/src/utils/hooks/use-cursor-color.ts
+++ b/src/utils/hooks/use-cursor-color.ts
@@ -23,7 +23,7 @@ export const CURSOR_COLORS = {
 
 export type CursorColor = keyof typeof CURSOR_COLORS;
 
-export const CURSOR_COLOR_OPTIONS = Object.keys(CURSOR_COLORS) as CursorColor[];
+export const CURSOR_COLOR_OPTIONS = ["ink", "cyan"] satisfies CursorColor[];
 
 type StoredCursorColor = CursorColor | "gray" | "amber";
 

--- a/src/utils/hooks/use-cursor-color.ts
+++ b/src/utils/hooks/use-cursor-color.ts
@@ -1,0 +1,46 @@
+import { atomWithStorage } from "jotai/utils";
+import { useAtom } from "jotai";
+import { LOCAL_STORAGE_KEYS } from "../constants";
+
+export const CURSOR_COLORS = {
+  ink: {
+    label: "Ink",
+    valueLight: "#262626",
+    valueDark: "#D4D4D4",
+    swatch: "#262626",
+    selectionLight: "rgba(38, 38, 38, 0.16)",
+    selectionDark: "rgba(212, 212, 212, 0.22)",
+  },
+  cyan: {
+    label: "Cyan",
+    valueLight: "#00C1FA",
+    valueDark: "#00C1FA",
+    swatch: "#00C1FA",
+    selectionLight: "rgba(0, 52, 73, 0.24)",
+    selectionDark: "rgba(0, 52, 73, 1)",
+  },
+} as const;
+
+export type CursorColor = keyof typeof CURSOR_COLORS;
+
+export const CURSOR_COLOR_OPTIONS = Object.keys(CURSOR_COLORS) as CursorColor[];
+
+type StoredCursorColor = CursorColor | "gray" | "amber";
+
+export const cursorColorAtom = atomWithStorage<StoredCursorColor>(LOCAL_STORAGE_KEYS.CURSOR_COLOR, "ink");
+
+export const resolveCursorColor = (cursorColor: StoredCursorColor): CursorColor =>
+  cursorColor in CURSOR_COLORS ? (cursorColor as CursorColor) : "ink";
+
+export const getCursorColor = (cursorColor: StoredCursorColor) => CURSOR_COLORS[resolveCursorColor(cursorColor)];
+
+export const useCursorColor = () => {
+  const [cursorColor, setCursorColor] = useAtom(cursorColorAtom);
+  const resolvedCursorColor = resolveCursorColor(cursorColor);
+
+  return {
+    cursorColor: resolvedCursorColor,
+    cursorColorValue: getCursorColor(resolvedCursorColor).swatch,
+    setCursorColor,
+  };
+};


### PR DESCRIPTION
## Summary

- Add a configurable cursor color setting with Ink and Cyan options.
- Render the cursor with the iA Writer-style drawn cursor, smoother blinking, and stored color preferences.
- Add a cursor color control to the System menu using the existing segmented-control visual treatment.

## Validation

- `pnpm build`