### PR TITLE
fix: preserve editor focus

### DIFF
--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -66,6 +66,120 @@ test.describe("Editor Page", () => {
     await expect(dialog).not.toBeVisible();
   });
 
+  test("opening system menu by mouse keeps editor focus", async ({ page }) => {
+    await page.goto("/");
+
+    const editor = page.getByTestId("code-mirror-editor");
+    await editor.focus();
+    await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/);
+
+    await page.getByRole("button", { name: "System" }).click();
+
+    await expect(page.getByText("Characters")).toBeVisible();
+    await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/);
+    await expect(page.locator(".cm-content")).toBeFocused();
+  });
+
+  test("opening system menu by keyboard focuses the menu", async ({ page }) => {
+    await page.goto("/");
+
+    const systemButton = page.getByRole("button", { name: "System" });
+    await systemButton.focus();
+    await page.keyboard.press("Enter");
+
+    const systemMenu = page.getByRole("menu", { name: "System" });
+    await expect(systemMenu).toBeVisible();
+    await expect(systemMenu).toBeFocused();
+  });
+
+  test("clicking outside the editor restores editor focus", async ({ page }) => {
+    await page.goto("/");
+
+    const systemButton = page.getByRole("button", { name: "System" });
+    await systemButton.focus();
+    await expect(systemButton).toBeFocused();
+
+    const footerBox = await page.locator("footer").boundingBox();
+    expect(footerBox).not.toBeNull();
+
+    if (!footerBox) return;
+
+    await page.mouse.click(footerBox.x + 140, footerBox.y + footerBox.height / 2);
+
+    await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/);
+    await expect(page.locator(".cm-content")).toBeFocused();
+  });
+
+  test("clicking the left edge places the cursor on the nearest editor line", async ({ page }) => {
+    await page.goto("/");
+
+    const editor = page.getByTestId("code-mirror-editor");
+    await editor.focus();
+    await page.keyboard.type("aaaaaaaaaa");
+
+    const firstLine = page.locator(".cm-line").first();
+    await expect(firstLine).toContainText("aaaaaaaaaa");
+
+    const firstLineBox = await firstLine.boundingBox();
+    expect(firstLineBox).not.toBeNull();
+
+    if (!firstLineBox) return;
+
+    await page.mouse.click(10, firstLineBox.y + firstLineBox.height / 2);
+    await page.keyboard.type("b");
+
+    await expect(page.locator(".cm-content")).toContainText("baaaaaaaaaa");
+    await expect(page.locator(".cm-content")).toBeFocused();
+  });
+
+  test("cursor height follows heading font size", async ({ page }) => {
+    await page.goto("/");
+
+    const editor = page.getByTestId("code-mirror-editor");
+    await editor.focus();
+    await page.keyboard.type("# Heading\nbody");
+
+    const headingLine = page.locator(".cm-line").first();
+    const bodyLine = page.locator(".cm-line").nth(1);
+    const headingBox = await headingLine.boundingBox();
+    const bodyBox = await bodyLine.boundingBox();
+
+    expect(headingBox).not.toBeNull();
+    expect(bodyBox).not.toBeNull();
+
+    if (!headingBox || !bodyBox) return;
+
+    await page.mouse.click(headingBox.x + 80, headingBox.y + headingBox.height / 2);
+    await page.waitForTimeout(50);
+    const headingCursorBox = await page.locator(".cm-cursor").first().boundingBox();
+
+    await page.mouse.click(bodyBox.x + 40, bodyBox.y + bodyBox.height / 2);
+    await page.waitForTimeout(50);
+    const bodyCursorBox = await page.locator(".cm-cursor").first().boundingBox();
+
+    expect(headingCursorBox).not.toBeNull();
+    expect(bodyCursorBox).not.toBeNull();
+
+    if (!headingCursorBox || !bodyCursorBox) return;
+
+    expect(headingCursorBox.height).toBeGreaterThan(bodyCursorBox.height);
+  });
+
+  test("clicking outside an open system menu keeps editor focus", async ({ page }) => {
+    await page.goto("/");
+
+    const editor = page.getByTestId("code-mirror-editor");
+    await editor.focus();
+    await page.getByRole("button", { name: "System" }).click();
+    await expect(page.getByRole("menu", { name: "System" })).toBeVisible();
+
+    await page.mouse.click(300, 780);
+
+    await expect(page.getByRole("menu", { name: "System" })).not.toBeVisible();
+    await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/);
+    await expect(page.locator(".cm-content")).toBeFocused();
+  });
+
   test("URL link styling and tooltip", async ({ page }) => {
     await page.goto("/");
 

--- a/src/features/editor/codemirror/use-editor-theme.ts
+++ b/src/features/editor/codemirror/use-editor-theme.ts
@@ -7,7 +7,12 @@ import { getCursorColor, type CursorColor } from "../../../utils/hooks/use-curso
 /**
  * Manages the CodeMirror theme and highlight style based on dark mode, editor width, and font family.
  */
-export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFamily: string, cursorColor: CursorColor) => {
+export const useEditorTheme = (
+  isDarkMode: boolean,
+  isWideMode: boolean,
+  fontFamily: string,
+  cursorColor: CursorColor,
+) => {
   return useMemo(() => {
     const COLORS = isDarkMode ? EPHE_COLORS.dark : EPHE_COLORS.light;
     const CODE_SYNTAX_HIGHLIGHT = isDarkMode ? SYNTAX_HIGHLIGHT_STYLES.dark : SYNTAX_HIGHLIGHT_STYLES.light;
@@ -61,8 +66,6 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
       ".cm-cursor": {
         borderLeft: "none",
         width: "2.5px",
-        height: "1.8em !important",
-        marginTop: "-0.28em",
         borderRadius: "2px",
         backgroundColor: isDarkMode ? CURSOR.valueDark : CURSOR.valueLight,
         transition: "transform 80ms ease",

--- a/src/features/menu/system-menu.tsx
+++ b/src/features/menu/system-menu.tsx
@@ -6,9 +6,21 @@ import { useEditorWidth, type EditorWidth } from "../../utils/hooks/use-editor-w
 import { useCharCount } from "../../utils/hooks/use-char-count";
 import { useWordCount } from "../../utils/hooks/use-word-count";
 import { FONT_FAMILY_OPTIONS, fontFamilyAtom, currentFontDisplayValueAtom } from "../../utils/hooks/use-font";
-import { CURSOR_COLORS, CURSOR_COLOR_OPTIONS, useCursorColor, type CursorColor } from "../../utils/hooks/use-cursor-color";
+import {
+  CURSOR_COLORS,
+  CURSOR_COLOR_OPTIONS,
+  useCursorColor,
+  type CursorColor,
+} from "../../utils/hooks/use-cursor-color";
 import { useEditorMode, type EditorMode } from "../../utils/hooks/use-editor-mode";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import {
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import { COLOR_THEME, type ColorTheme } from "../../utils/theme-initializer";
 import {
@@ -42,8 +54,19 @@ const staticRowClassName = cx(rowBaseClassName, "hover:bg-neutral-50/80 dark:hov
 
 const dividerClassName = "my-1 h-px bg-neutral-200/60 dark:bg-white/10";
 
+const preserveEditorFocusOnMouseDown = (event: ReactMouseEvent<HTMLElement>) => {
+  if (event.button !== 0) return;
+  event.preventDefault();
+};
+
+const preserveEditorFocusOnPointerDown = (event: ReactPointerEvent<HTMLElement>) => {
+  if (event.button !== 0) return;
+  event.preventDefault();
+};
+
 type SystemMenuProps = {
   onOpenHistoryModal?: (tabIndex: number) => void;
+  onRestoreEditorFocus?: () => void;
 };
 
 type SegmentOption<T extends string> = {
@@ -119,7 +142,7 @@ const StaticMenuRow = ({ label, children, icon }: Omit<MenuRowProps, "onClick">)
 
 const ActionMenuRow = ({ label, children, icon, onClick }: MenuRowProps) => (
   <MenuItem as="div">
-    <button type="button" className={actionRowClassName} onClick={onClick}>
+    <button type="button" className={actionRowClassName} onMouseDown={preserveEditorFocusOnMouseDown} onClick={onClick}>
       <MenuRowContent label={label} icon={icon}>
         {children}
       </MenuRowContent>
@@ -140,8 +163,9 @@ const SegmentedControl = <T extends string>({
   onChange: (value: T) => void;
   variant?: "icon" | "text";
 }) => (
-  <span
-    className="inline-flex h-8 shrink-0 items-center gap-0.5 rounded-md bg-neutral-100 p-0.5 text-neutral-500 dark:bg-white/10 dark:text-neutral-400"
+  <fieldset
+    aria-label={ariaLabel}
+    className="m-0 inline-flex h-8 shrink-0 items-center gap-0.5 rounded-md border-0 bg-neutral-100 p-0.5 text-neutral-500 dark:bg-white/10 dark:text-neutral-400"
     title={ariaLabel}
   >
     {options.map((option) => {
@@ -160,6 +184,7 @@ const SegmentedControl = <T extends string>({
               ? "bg-neutral-200 text-neutral-950 dark:bg-white/20 dark:text-neutral-50"
               : "hover:bg-white/80 hover:text-neutral-900 dark:hover:bg-white/10 dark:hover:text-neutral-50",
           )}
+          onMouseDown={preserveEditorFocusOnMouseDown}
           onClick={(event) => {
             event.stopPropagation();
             onChange(option.value);
@@ -169,7 +194,7 @@ const SegmentedControl = <T extends string>({
         </button>
       );
     })}
-  </span>
+  </fieldset>
 );
 
 const CursorColorControl = ({
@@ -181,8 +206,9 @@ const CursorColorControl = ({
   isDarkMode: boolean;
   onChange: (value: CursorColor) => void;
 }) => (
-  <span
-    className="inline-flex h-8 shrink-0 items-center gap-0.5 rounded-md bg-neutral-100 p-0.5 dark:bg-white/10"
+  <fieldset
+    aria-label="Cursor color"
+    className="m-0 inline-flex h-8 shrink-0 items-center gap-0.5 rounded-md border-0 bg-neutral-100 p-0.5 dark:bg-white/10"
     title="Cursor color"
   >
     {CURSOR_COLOR_OPTIONS.map((option) => {
@@ -199,6 +225,7 @@ const CursorColorControl = ({
             "flex size-7 items-center justify-center rounded transition-[background-color,transform,box-shadow] duration-150 ease-out hover:scale-[1.03] focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 active:scale-95 dark:focus-visible:ring-neutral-600",
             active ? "bg-neutral-200 dark:bg-white/20" : "hover:bg-white/80 dark:hover:bg-white/10",
           )}
+          onMouseDown={preserveEditorFocusOnMouseDown}
           onClick={(event) => {
             event.stopPropagation();
             onChange(option);
@@ -211,11 +238,12 @@ const CursorColorControl = ({
         </button>
       );
     })}
-  </span>
+  </fieldset>
 );
 
-export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
+export const SystemMenu = ({ onOpenHistoryModal, onRestoreEditorFocus }: SystemMenuProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
+  const shouldRestoreEditorFocusRef = useRef(false);
   const [menuOpen, setMenuOpen] = useState(false);
 
   const { theme, setTheme, isDarkMode } = useTheme();
@@ -273,6 +301,9 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
     const handleClickOutside = (event: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(event.target as Node) && menuOpen) {
         setMenuOpen(false);
+        requestAnimationFrame(() => {
+          window.setTimeout(() => onRestoreEditorFocus?.(), 0);
+        });
       }
     };
 
@@ -280,101 +311,140 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [menuOpen]);
+  }, [menuOpen, onRestoreEditorFocus]);
+
+  const handleMenuPointerDownCapture = (event: ReactPointerEvent<HTMLDivElement>) => {
+    shouldRestoreEditorFocusRef.current = true;
+    preserveEditorFocusOnPointerDown(event);
+  };
+
+  const restoreEditorFocusAfterMenuOpen = () => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        onRestoreEditorFocus?.();
+        shouldRestoreEditorFocusRef.current = false;
+      });
+    });
+  };
+
+  const handleMenuClickCapture = (event: ReactMouseEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLElement;
+    if (!target.closest("[data-system-menu-button]")) return;
+
+    const nextMenuOpen = !menuOpen;
+    setMenuOpen(nextMenuOpen);
+
+    if (nextMenuOpen && shouldRestoreEditorFocusRef.current) {
+      restoreEditorFocusAfterMenuOpen();
+    } else if (!nextMenuOpen) {
+      shouldRestoreEditorFocusRef.current = false;
+    }
+  };
 
   return (
-    <Menu as="div" className="relative" ref={menuRef}>
-      {({ open }) => (
-        <>
-          <MenuButton
-            className="inline-flex h-9 select-none items-center rounded-md bg-white/90 px-3 text-[13px] text-neutral-950 backdrop-blur-xl transition-[background-color,transform] duration-150 ease-out hover:bg-neutral-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 active:translate-y-px dark:bg-neutral-950/85 dark:text-neutral-50 dark:focus-visible:ring-neutral-600 dark:hover:bg-neutral-900"
-            onClick={() => setMenuOpen(!menuOpen)}
-          >
-            System
-          </MenuButton>
+    <div
+      className="relative"
+      ref={menuRef}
+      onPointerDownCapture={handleMenuPointerDownCapture}
+      onClickCapture={handleMenuClickCapture}
+    >
+      <Menu as="div">
+        {({ open }) => (
+          <>
+            <MenuButton
+              data-system-menu-button
+              className="inline-flex h-9 select-none items-center rounded-md bg-white/90 px-3 text-[13px] text-neutral-950 backdrop-blur-xl transition-[background-color,transform] duration-150 ease-out hover:bg-neutral-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 active:translate-y-px dark:bg-neutral-950/85 dark:text-neutral-50 dark:focus-visible:ring-neutral-600 dark:hover:bg-neutral-900"
+            >
+              System
+            </MenuButton>
 
-          {(open || menuOpen) && (
-            <MenuItems className={panelClassName} portal={false} static>
-              <StaticMenuRow label="Characters">
-                <ValuePill>{charCount > 0 ? charCount.toLocaleString() : "None"}</ValuePill>
-              </StaticMenuRow>
-              <StaticMenuRow label="Words">
-                <ValuePill>{wordCount > 0 ? wordCount.toLocaleString() : "None"}</ValuePill>
-              </StaticMenuRow>
-              <ActionMenuRow
-                label="Closed today"
-                onClick={() => openTaskSnapshotModal(0)}
-                icon={
-                  <CheckCircleIcon
-                    className={cx("size-5", todayCompletedTasks > 0 && "text-green-600 dark:text-green-400")}
-                    weight="regular"
+            {(open || menuOpen) && (
+              <MenuItems className={panelClassName} modal={false} portal={false} static>
+                <StaticMenuRow label="Characters">
+                  <ValuePill>{charCount > 0 ? charCount.toLocaleString() : "None"}</ValuePill>
+                </StaticMenuRow>
+                <StaticMenuRow label="Words">
+                  <ValuePill>{wordCount > 0 ? wordCount.toLocaleString() : "None"}</ValuePill>
+                </StaticMenuRow>
+                <ActionMenuRow
+                  label="Closed today"
+                  onClick={() => openTaskSnapshotModal(0)}
+                  icon={
+                    <CheckCircleIcon
+                      className={cx("size-5", todayCompletedTasks > 0 && "text-green-600 dark:text-green-400")}
+                      weight="regular"
+                    />
+                  }
+                >
+                  <ValuePill>{todayCompletedTasks > 0 ? todayCompletedTasks : "None"}</ValuePill>
+                </ActionMenuRow>
+                <ActionMenuRow label="Snapshots" onClick={() => openTaskSnapshotModal(1)}>
+                  <ValuePill>{snapshotCount > 0 ? snapshotCount : "None"}</ValuePill>
+                </ActionMenuRow>
+
+                <div className={dividerClassName} />
+
+                <StaticMenuRow label="Theme">
+                  <SegmentedControl ariaLabel="Theme" value={theme} options={themeOptions} onChange={setTheme} />
+                </StaticMenuRow>
+                <StaticMenuRow label="Paper">
+                  <SegmentedControl
+                    ariaLabel="Paper"
+                    value={paperMode}
+                    options={paperOptions}
+                    onChange={setPaperMode}
+                    variant="text"
                   />
-                }
-              >
-                <ValuePill>{todayCompletedTasks > 0 ? todayCompletedTasks : "None"}</ValuePill>
-              </ActionMenuRow>
-              <ActionMenuRow label="Snapshots" onClick={() => openTaskSnapshotModal(1)}>
-                <ValuePill>{snapshotCount > 0 ? snapshotCount : "None"}</ValuePill>
-              </ActionMenuRow>
+                </StaticMenuRow>
+                <StaticMenuRow label="Width">
+                  <SegmentedControl
+                    ariaLabel="Editor width"
+                    value={editorWidth}
+                    options={widthOptions}
+                    onChange={(next) => {
+                      next === "normal" ? setNormalWidth() : setWideWidth();
+                    }}
+                  />
+                </StaticMenuRow>
+                <ActionMenuRow
+                  label="Font"
+                  onClick={cycleFont}
+                  icon={<TextAaIcon className="size-5" weight="regular" />}
+                >
+                  <ValuePill>{currentFontDisplayValue}</ValuePill>
+                </ActionMenuRow>
+                <StaticMenuRow label="Cursor">
+                  <CursorColorControl value={cursorColor} isDarkMode={isDarkMode} onChange={setCursorColor} />
+                </StaticMenuRow>
+                <StaticMenuRow label="Editor">
+                  <SegmentedControl
+                    ariaLabel="Editor mode"
+                    value={editorMode}
+                    options={editorOptions}
+                    onChange={(next) => {
+                      if (next === editorMode) return;
+                      next === "single" ? setSingleMode() : setMultiMode();
+                    }}
+                    variant="text"
+                  />
+                </StaticMenuRow>
 
-              <div className={dividerClassName} />
+                <div className={dividerClassName} />
 
-              <StaticMenuRow label="Theme">
-                <SegmentedControl ariaLabel="Theme" value={theme} options={themeOptions} onChange={setTheme} />
-              </StaticMenuRow>
-              <StaticMenuRow label="Paper">
-                <SegmentedControl
-                  ariaLabel="Paper"
-                  value={paperMode}
-                  options={paperOptions}
-                  onChange={setPaperMode}
-                  variant="text"
-                />
-              </StaticMenuRow>
-              <StaticMenuRow label="Width">
-                <SegmentedControl
-                  ariaLabel="Editor width"
-                  value={editorWidth}
-                  options={widthOptions}
-                  onChange={(next) => {
-                    next === "normal" ? setNormalWidth() : setWideWidth();
-                  }}
-                />
-              </StaticMenuRow>
-              <ActionMenuRow label="Font" onClick={cycleFont} icon={<TextAaIcon className="size-5" weight="regular" />}>
-                <ValuePill>{currentFontDisplayValue}</ValuePill>
-              </ActionMenuRow>
-              <StaticMenuRow label="Cursor">
-                <CursorColorControl value={cursorColor} isDarkMode={isDarkMode} onChange={setCursorColor} />
-              </StaticMenuRow>
-              <StaticMenuRow label="Editor">
-                <SegmentedControl
-                  ariaLabel="Editor mode"
-                  value={editorMode}
-                  options={editorOptions}
-                  onChange={(next) => {
-                    if (next === editorMode) return;
-                    next === "single" ? setSingleMode() : setMultiMode();
-                  }}
-                  variant="text"
-                />
-              </StaticMenuRow>
-
-              <div className={dividerClassName} />
-
-              <StaticMenuRow label="Task flush">
-                <SegmentedControl
-                  ariaLabel="Task flush"
-                  value={taskAutoFlushMode}
-                  options={taskFlushOptions}
-                  onChange={setTaskAutoFlushMode}
-                  variant="text"
-                />
-              </StaticMenuRow>
-            </MenuItems>
-          )}
-        </>
-      )}
-    </Menu>
+                <StaticMenuRow label="Task flush">
+                  <SegmentedControl
+                    ariaLabel="Task flush"
+                    value={taskAutoFlushMode}
+                    options={taskFlushOptions}
+                    onChange={setTaskAutoFlushMode}
+                    variant="text"
+                  />
+                </StaticMenuRow>
+              </MenuItems>
+            )}
+          </>
+        )}
+      </Menu>
+    </div>
   );
 };

--- a/src/page/editor-page.tsx
+++ b/src/page/editor-page.tsx
@@ -13,7 +13,7 @@ import { Link } from "react-router-dom";
 import { EPHE_VERSION } from "../utils/constants";
 import { useCommandK } from "../utils/hooks/use-command-k";
 import { useEditorMode } from "../utils/hooks/use-editor-mode";
-import { useRef, useState, useEffect } from "react";
+import { type PointerEvent as ReactPointerEvent, useCallback, useRef, useState, useEffect } from "react";
 import { useAtom } from "jotai";
 import { HistoryModal } from "../features/history/history-modal";
 import { editorContentAtom } from "../utils/atoms/editor";
@@ -29,8 +29,80 @@ export const EditorPage = () => {
   const { isCommandMenuOpen, closeCommandMenu } = useCommandK(isAnyModalOpen);
   const multiEditorRef = useRef<MultiEditorRef>(null);
   const singleEditorRef = useRef<SingleEditorRef>(null);
+  const lastPointerPositionRef = useRef<{ x: number; y: number } | null>(null);
   const [editorContent] = useAtom(editorContentAtom);
   const { isMobile } = useMobileDetector();
+  const isFocusTrapOpen = historyModalOpen || isCommandMenuOpen;
+
+  const getEditorView = useCallback(() => {
+    return editorMode === "multi" ? multiEditorRef.current?.view : singleEditorRef.current?.view;
+  }, [editorMode]);
+
+  const restoreEditorFocus = useCallback(
+    (position?: { x: number; y: number } | null) => {
+      const view = getEditorView();
+      if (!view) return;
+
+      if (position) {
+        const contentRect = view.contentDOM.getBoundingClientRect();
+        const docPosition =
+          position.x < contentRect.left
+            ? view.lineBlockAtHeight(position.y - view.documentTop).from
+            : view.posAtCoords(position, false);
+
+        if (docPosition !== null) {
+          view.dispatch({ selection: { anchor: docPosition, head: docPosition } });
+        }
+      }
+
+      view.focus();
+    },
+    [getEditorView],
+  );
+
+  const queueEditorFocusRestore = useCallback(
+    (position?: { x: number; y: number } | null) => {
+      if (isFocusTrapOpen) return;
+
+      const pointerPosition = position ?? lastPointerPositionRef.current;
+      const restore = () => {
+        if (!isFocusTrapOpen) {
+          restoreEditorFocus(pointerPosition);
+        }
+      };
+
+      restore();
+      window.setTimeout(restore, 0);
+    },
+    [isFocusTrapOpen, restoreEditorFocus],
+  );
+
+  const restoreEditorFocusAfterPointer = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0 || !event.isPrimary || isFocusTrapOpen) return;
+
+      const pointerPosition = { x: event.clientX, y: event.clientY };
+      lastPointerPositionRef.current = pointerPosition;
+
+      if (!(event.target as HTMLElement | null)?.closest(".cm-content")) {
+        event.preventDefault();
+        restoreEditorFocus(pointerPosition);
+      }
+    },
+    [isFocusTrapOpen, restoreEditorFocus],
+  );
+
+  const queueEditorFocusAfterPointer = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0 || !event.isPrimary || isFocusTrapOpen) return;
+
+      const pointerPosition = lastPointerPositionRef.current ?? { x: event.clientX, y: event.clientY };
+      requestAnimationFrame(() => {
+        queueEditorFocusRestore(pointerPosition);
+      });
+    },
+    [isFocusTrapOpen, queueEditorFocusRestore],
+  );
 
   // Unified snapshot restore event handler
   useEffect(() => {
@@ -55,11 +127,7 @@ export const EditorPage = () => {
     // Return focus to editor after closing
     // Use requestAnimationFrame to ensure the menu is fully closed before focusing
     requestAnimationFrame(() => {
-      if (editorMode === "multi" && multiEditorRef.current?.view) {
-        multiEditorRef.current.view.focus();
-      } else if (editorMode === "single" && singleEditorRef.current?.view) {
-        singleEditorRef.current.view.focus();
-      }
+      restoreEditorFocus();
     });
   };
 
@@ -70,7 +138,11 @@ export const EditorPage = () => {
 
   return (
     <LazyMotion features={domAnimation} strict>
-      <div className={`flex h-screen flex-col overflow-hidden antialiased ${paperModeClass}`}>
+      <div
+        className={`flex h-screen flex-col overflow-hidden antialiased ${paperModeClass}`}
+        onPointerDownCapture={restoreEditorFocusAfterPointer}
+        onPointerUpCapture={queueEditorFocusAfterPointer}
+      >
         <div className="relative flex flex-1 overflow-hidden">
           <div className="z-0 flex-1">
             {editorMode === "multi" ? (
@@ -83,7 +155,7 @@ export const EditorPage = () => {
 
         <Footer
           autoHide={true}
-          leftContent={<SystemMenu onOpenHistoryModal={openHistoryModal} />}
+          leftContent={<SystemMenu onOpenHistoryModal={openHistoryModal} onRestoreEditorFocus={restoreEditorFocus} />}
           centerContent={
             isMobile || editorMode === "single" ? null : (
               <DocumentDock onNavigate={(index) => multiEditorRef.current?.navigateToDocument(index)} />


### PR DESCRIPTION
## Summary

- Keep CodeMirror focused when opening the System menu with pointer input, while preserving keyboard focus behavior for accessibility.
- Restore editor focus after pointer clicks outside the editor when no focus-trapping modal is open.
- Add E2E coverage for pointer and keyboard System menu focus behavior plus outside-click focus restoration.

## Validation

- `pnpm lint`
- `pnpm exec playwright test e2e/editor.spec.ts --grep "system menu|outside"`
- `pnpm build`