### PR TITLE
fix: let cursor height follow line size

### DIFF
--- a/src/features/editor/codemirror/use-editor-theme.ts
+++ b/src/features/editor/codemirror/use-editor-theme.ts
@@ -61,8 +61,6 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
       ".cm-cursor": {
         borderLeft: "none",
         width: "2.5px",
-        height: "1.8em !important",
-        marginTop: "-0.28em",
         borderRadius: "2px",
         backgroundColor: isDarkMode ? CURSOR.valueDark : CURSOR.valueLight,
         transition: "transform 80ms ease",


### PR DESCRIPTION
## Summary

- Remove the fixed drawn-cursor height and vertical offset so CodeMirror can size the cursor from the active line.
- This keeps heading rows such as H1/H2 from using the same cursor height as body text.

## Validation

- `pnpm lint`
- `pnpm build`
- Browser verification on `http://127.0.0.1:3014/`: H1 cursor height 25px, body cursor height 20px