### PR TITLE
fix: editor cursor and selection rendering

### DIFF
--- a/src/features/editor/codemirror/cursor-layer.ts
+++ b/src/features/editor/codemirror/cursor-layer.ts
@@ -1,0 +1,23 @@
+import type { Extension } from "@codemirror/state";
+import { layer, RectangleMarker } from "@codemirror/view";
+
+export const customCursorLayer = (): Extension =>
+  layer({
+    above: true,
+    markers(view) {
+      const { main, ranges } = view.state.selection;
+      const markers: RectangleMarker[] = [];
+
+      for (const range of ranges) {
+        if (!range.empty) continue;
+        const className = range === main ? "cm-cursor cm-cursor-primary" : "cm-cursor cm-cursor-secondary";
+        markers.push(...RectangleMarker.forRange(view, className, range));
+      }
+
+      return markers;
+    },
+    update(update) {
+      return update.docChanged || update.selectionSet || update.viewportChanged;
+    },
+    class: "cm-cursorLayer",
+  });

--- a/src/features/editor/codemirror/cursor-layer.ts
+++ b/src/features/editor/codemirror/cursor-layer.ts
@@ -1,23 +1,22 @@
 import type { Extension } from "@codemirror/state";
 import { layer, RectangleMarker } from "@codemirror/view";
 
-export const customCursorLayer = (): Extension =>
-  layer({
-    above: true,
-    markers(view) {
-      const { main, ranges } = view.state.selection;
-      const markers: RectangleMarker[] = [];
+export const customCursorLayer: Extension = layer({
+  above: true,
+  markers(view) {
+    const { main, ranges } = view.state.selection;
+    const markers: RectangleMarker[] = [];
 
-      for (const range of ranges) {
-        if (!range.empty) continue;
-        const className = range === main ? "cm-cursor cm-cursor-primary" : "cm-cursor cm-cursor-secondary";
-        markers.push(...RectangleMarker.forRange(view, className, range));
-      }
+    for (const range of ranges) {
+      if (!range.empty) continue;
+      const className = range === main ? "cm-epheCursor cm-epheCursor-primary" : "cm-epheCursor";
+      markers.push(...RectangleMarker.forRange(view, className, range));
+    }
 
-      return markers;
-    },
-    update(update) {
-      return update.docChanged || update.selectionSet || update.viewportChanged;
-    },
-    class: "cm-cursorLayer",
-  });
+    return markers;
+  },
+  update(update) {
+    return update.docChanged || update.selectionSet || update.viewportChanged;
+  },
+  class: "cm-epheCursorLayer",
+});

--- a/src/features/editor/codemirror/use-editor-theme.ts
+++ b/src/features/editor/codemirror/use-editor-theme.ts
@@ -54,7 +54,7 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
         lineHeight: "1.6",
         maxWidth: isWideMode ? "100%" : "680px",
         margin: "0 auto",
-        caretColor: "transparent",
+        caretColor: isDarkMode ? CURSOR.valueDark : CURSOR.valueLight,
         fontFeatureSettings: fontFamily.includes("Mynerve") ? '"calt" off, "salt" off' : "normal",
         fontVariantLigatures: fontFamily.includes("Mynerve") ? "none" : "normal",
       },
@@ -78,9 +78,6 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
         "0%, 18%": { opacity: 1 },
         "50%": { opacity: 0 },
         "82%, 100%": { opacity: 1 },
-      },
-      ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
-        display: "none",
       },
       ".cm-content::selection, .cm-content ::selection, .cm-line::selection, .cm-line ::selection": {
         backgroundColor: `${isDarkMode ? CURSOR.selectionDark : CURSOR.selectionLight} !important`,

--- a/src/features/editor/codemirror/use-editor-theme.ts
+++ b/src/features/editor/codemirror/use-editor-theme.ts
@@ -54,11 +54,12 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
         lineHeight: "1.6",
         maxWidth: isWideMode ? "100%" : "680px",
         margin: "0 auto",
-        caretColor: isDarkMode ? CURSOR.valueDark : CURSOR.valueLight,
+        caretColor: "transparent",
         fontFeatureSettings: fontFamily.includes("Mynerve") ? '"calt" off, "salt" off' : "normal",
         fontVariantLigatures: fontFamily.includes("Mynerve") ? "none" : "normal",
       },
       ".cm-cursor": {
+        display: "block",
         borderLeft: "none",
         width: "2.5px",
         borderRadius: "2px",
@@ -68,6 +69,10 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
       ".cm-cursorLayer": {
         animationDuration: "1.2s !important",
         animationTimingFunction: "ease-in-out !important",
+        pointerEvents: "none",
+      },
+      "&.cm-focused > .cm-scroller > .cm-cursorLayer": {
+        animation: "steps(1) cm-blink 1.2s infinite",
       },
       "@keyframes cm-blink": {
         "0%, 18%": { opacity: 1 },

--- a/src/features/editor/codemirror/use-editor-theme.ts
+++ b/src/features/editor/codemirror/use-editor-theme.ts
@@ -61,8 +61,6 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
       ".cm-cursor": {
         borderLeft: "none",
         width: "2.5px",
-        height: "1.8em !important",
-        marginTop: "-0.28em",
         borderRadius: "2px",
         backgroundColor: isDarkMode ? CURSOR.valueDark : CURSOR.valueLight,
         transition: "transform 80ms ease",

--- a/src/features/editor/codemirror/use-editor-theme.ts
+++ b/src/features/editor/codemirror/use-editor-theme.ts
@@ -80,7 +80,10 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
         "82%, 100%": { opacity: 1 },
       },
       ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
-        backgroundColor: isDarkMode ? CURSOR.selectionDark : CURSOR.selectionLight,
+        display: "none",
+      },
+      ".cm-content::selection, .cm-content ::selection, .cm-line::selection, .cm-line ::selection": {
+        backgroundColor: `${isDarkMode ? CURSOR.selectionDark : CURSOR.selectionLight} !important`,
       },
       "&.cm-editor": {
         outline: "none",

--- a/src/features/editor/codemirror/use-editor-theme.ts
+++ b/src/features/editor/codemirror/use-editor-theme.ts
@@ -58,20 +58,20 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
         fontFeatureSettings: fontFamily.includes("Mynerve") ? '"calt" off, "salt" off' : "normal",
         fontVariantLigatures: fontFamily.includes("Mynerve") ? "none" : "normal",
       },
-      ".cm-cursor": {
-        display: "block",
+      ".cm-epheCursor": {
         borderLeft: "none",
         width: "2.5px",
         borderRadius: "2px",
         backgroundColor: isDarkMode ? CURSOR.valueDark : CURSOR.valueLight,
+        pointerEvents: "none",
         transition: "transform 80ms ease",
       },
-      ".cm-cursorLayer": {
+      ".cm-epheCursorLayer": {
         animationDuration: "1.2s !important",
         animationTimingFunction: "ease-in-out !important",
         pointerEvents: "none",
       },
-      "&.cm-focused > .cm-scroller > .cm-cursorLayer": {
+      "&.cm-focused > .cm-scroller > .cm-epheCursorLayer": {
         animation: "steps(1) cm-blink 1.2s infinite",
       },
       "@keyframes cm-blink": {

--- a/src/features/editor/codemirror/use-markdown-editor.ts
+++ b/src/features/editor/codemirror/use-markdown-editor.ts
@@ -204,7 +204,7 @@ export const useMarkdownEditor = (
         }),
 
         EditorView.lineWrapping,
-        customCursorLayer(),
+        customCursorLayer,
         EditorView.updateListener.of((update) => {
           if (update.docChanged) {
             // Skip updates from programmatic changes (formatting, restore, etc.)

--- a/src/features/editor/codemirror/use-markdown-editor.ts
+++ b/src/features/editor/codemirror/use-markdown-editor.ts
@@ -22,6 +22,7 @@ import { useDebouncedCallback } from "use-debounce";
 import { editorContentAtom } from "../../../utils/atoms/editor";
 import { currentFontValueAtom } from "../../../utils/hooks/use-font";
 import { cursorColorAtom, resolveCursorColor } from "../../../utils/hooks/use-cursor-color";
+import { customCursorLayer } from "./cursor-layer";
 
 const useMarkdownFormatter = () => {
   const ref = useRef<DprintMarkdownFormatter | null>(null);
@@ -203,6 +204,7 @@ export const useMarkdownEditor = (
         }),
 
         EditorView.lineWrapping,
+        customCursorLayer(),
         EditorView.updateListener.of((update) => {
           if (update.docChanged) {
             // Skip updates from programmatic changes (formatting, restore, etc.)

--- a/src/features/editor/codemirror/use-markdown-editor.ts
+++ b/src/features/editor/codemirror/use-markdown-editor.ts
@@ -2,7 +2,7 @@ import { defaultKeymap, historyKeymap, history } from "@codemirror/commands";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { languages } from "@codemirror/language-data";
 import { Compartment, EditorState, Prec } from "@codemirror/state";
-import { EditorView, drawSelection, keymap, placeholder } from "@codemirror/view";
+import { EditorView, keymap, placeholder } from "@codemirror/view";
 import { useAtom, useAtomValue } from "jotai";
 import { useRef, useEffect, useLayoutEffect, useState } from "react";
 import { showToast } from "../../../utils/components/toast";
@@ -203,7 +203,6 @@ export const useMarkdownEditor = (
         }),
 
         EditorView.lineWrapping,
-        drawSelection(),
         EditorView.updateListener.of((update) => {
           if (update.docChanged) {
             // Skip updates from programmatic changes (formatting, restore, etc.)


### PR DESCRIPTION
## Summary
- Let the custom editor cursor follow the rendered line height instead of forcing a fixed size.
- Disable CodeMirror's custom selection layer so all-select uses native text selection instead of wide line rectangles.
- Add a cursor-only CodeMirror layer with Ephe-specific CSS classes to preserve the 2.5px rounded custom cursor without relying on CodeMirror's `drawSelection()` cursor classes.

## Why
CodeMirror's `drawSelection()` hides the browser's native selection and paints full-line selection rectangles. That made all-select look horizontally oversized around short lines and blank lines. Removing it restored native selection, but also removed the custom cursor layer.

This PR now uses native selection plus a dedicated cursor-only layer. The cursor layer uses Ephe-specific classes (`cm-epheCursor*`) so it does not collide with CodeMirror's built-in `.cm-cursor` styles.

## Validation
- `pnpm lint`
- `pnpm build`
- Verified locally in the browser that all-select remains visible, no wide selection block is rendered, and the custom cursor style is preserved.
