### PR TITLE
fix: preserve editor focus after system menu changes

### DIFF
--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -24,6 +24,23 @@ test.describe("Editor Page", () => {
     await expect(editorContent).toContainText("Hello World");
   });
 
+  test("keeps editor input active after changing system menu controls", async ({ page }) => {
+    await page.goto("/");
+
+    await page.waitForSelector(".cm-editor");
+    const editor = page.getByTestId("code-mirror-editor");
+    await editor.focus();
+    await page.keyboard.type("before ");
+
+    await page.locator("footer").getByRole("button", { name: "System" }).first().click();
+    await page.locator(".cosmos-menu-panel").getByRole("button", { name: "System" }).click();
+
+    await expect(page.locator(".cm-editor")).toHaveClass(/cm-focused/);
+    await page.keyboard.type("after");
+
+    await expect(page.locator(".cm-content")).toContainText("before after");
+  });
+
   test("open and close command menu", async ({ page }) => {
     await page.goto("/");
 

--- a/src/features/menu/system-menu.tsx
+++ b/src/features/menu/system-menu.tsx
@@ -6,9 +6,14 @@ import { useEditorWidth, type EditorWidth } from "../../utils/hooks/use-editor-w
 import { useCharCount } from "../../utils/hooks/use-char-count";
 import { useWordCount } from "../../utils/hooks/use-word-count";
 import { FONT_FAMILY_OPTIONS, fontFamilyAtom, currentFontDisplayValueAtom } from "../../utils/hooks/use-font";
-import { CURSOR_COLORS, CURSOR_COLOR_OPTIONS, useCursorColor, type CursorColor } from "../../utils/hooks/use-cursor-color";
+import {
+  CURSOR_COLORS,
+  CURSOR_COLOR_OPTIONS,
+  useCursorColor,
+  type CursorColor,
+} from "../../utils/hooks/use-cursor-color";
 import { useEditorMode, type EditorMode } from "../../utils/hooks/use-editor-mode";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { type MouseEvent as ReactMouseEvent, type ReactNode, useEffect, useRef, useState } from "react";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import { COLOR_THEME, type ColorTheme } from "../../utils/theme-initializer";
 import {
@@ -44,6 +49,7 @@ const dividerClassName = "my-1 h-px bg-neutral-200/60 dark:bg-white/10";
 
 type SystemMenuProps = {
   onOpenHistoryModal?: (tabIndex: number) => void;
+  onRestoreEditorFocus?: () => void;
 };
 
 type SegmentOption<T extends string> = {
@@ -57,6 +63,11 @@ type MenuRowProps = {
   children?: ReactNode;
   icon?: ReactNode;
   onClick?: () => void;
+};
+
+const preserveEditorFocusOnMouseDown = (event: ReactMouseEvent<HTMLElement>) => {
+  if (event.button !== 0) return;
+  event.preventDefault();
 };
 
 const useTodayCompletedTasks = (menuOpen: boolean) => {
@@ -119,7 +130,7 @@ const StaticMenuRow = ({ label, children, icon }: Omit<MenuRowProps, "onClick">)
 
 const ActionMenuRow = ({ label, children, icon, onClick }: MenuRowProps) => (
   <MenuItem as="div">
-    <button type="button" className={actionRowClassName} onClick={onClick}>
+    <button type="button" className={actionRowClassName} onMouseDown={preserveEditorFocusOnMouseDown} onClick={onClick}>
       <MenuRowContent label={label} icon={icon}>
         {children}
       </MenuRowContent>
@@ -160,6 +171,7 @@ const SegmentedControl = <T extends string>({
               ? "bg-neutral-200 text-neutral-950 dark:bg-white/20 dark:text-neutral-50"
               : "hover:bg-white/80 hover:text-neutral-900 dark:hover:bg-white/10 dark:hover:text-neutral-50",
           )}
+          onMouseDown={preserveEditorFocusOnMouseDown}
           onClick={(event) => {
             event.stopPropagation();
             onChange(option.value);
@@ -199,6 +211,7 @@ const CursorColorControl = ({
             "flex size-7 items-center justify-center rounded transition-[background-color,transform,box-shadow] duration-150 ease-out hover:scale-[1.03] focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 active:scale-95 dark:focus-visible:ring-neutral-600",
             active ? "bg-neutral-200 dark:bg-white/20" : "hover:bg-white/80 dark:hover:bg-white/10",
           )}
+          onMouseDown={preserveEditorFocusOnMouseDown}
           onClick={(event) => {
             event.stopPropagation();
             onChange(option);
@@ -214,7 +227,7 @@ const CursorColorControl = ({
   </span>
 );
 
-export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
+export const SystemMenu = ({ onOpenHistoryModal, onRestoreEditorFocus }: SystemMenuProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -264,9 +277,16 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
     onOpenHistoryModal(tabIndex);
   };
 
+  const restoreEditorFocusSoon = () => {
+    requestAnimationFrame(() => {
+      onRestoreEditorFocus?.();
+    });
+  };
+
   const cycleFont = () => {
     const currentIndex = FONT_FAMILY_OPTIONS.indexOf(fontFamily);
     setFontFamily(FONT_FAMILY_OPTIONS[(currentIndex + 1) % FONT_FAMILY_OPTIONS.length]);
+    restoreEditorFocusSoon();
   };
 
   useEffect(() => {
@@ -288,13 +308,14 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
         <>
           <MenuButton
             className="inline-flex h-9 select-none items-center rounded-md bg-white/90 px-3 text-[13px] text-neutral-950 backdrop-blur-xl transition-[background-color,transform] duration-150 ease-out hover:bg-neutral-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 active:translate-y-px dark:bg-neutral-950/85 dark:text-neutral-50 dark:focus-visible:ring-neutral-600 dark:hover:bg-neutral-900"
+            onMouseDown={preserveEditorFocusOnMouseDown}
             onClick={() => setMenuOpen(!menuOpen)}
           >
             System
           </MenuButton>
 
           {(open || menuOpen) && (
-            <MenuItems className={panelClassName} portal={false} static>
+            <MenuItems className={panelClassName} modal={false} portal={false} static>
               <StaticMenuRow label="Characters">
                 <ValuePill>{charCount > 0 ? charCount.toLocaleString() : "None"}</ValuePill>
               </StaticMenuRow>
@@ -320,14 +341,25 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
               <div className={dividerClassName} />
 
               <StaticMenuRow label="Theme">
-                <SegmentedControl ariaLabel="Theme" value={theme} options={themeOptions} onChange={setTheme} />
+                <SegmentedControl
+                  ariaLabel="Theme"
+                  value={theme}
+                  options={themeOptions}
+                  onChange={(next) => {
+                    setTheme(next);
+                    restoreEditorFocusSoon();
+                  }}
+                />
               </StaticMenuRow>
               <StaticMenuRow label="Paper">
                 <SegmentedControl
                   ariaLabel="Paper"
                   value={paperMode}
                   options={paperOptions}
-                  onChange={setPaperMode}
+                  onChange={(next) => {
+                    setPaperMode(next);
+                    restoreEditorFocusSoon();
+                  }}
                   variant="text"
                 />
               </StaticMenuRow>
@@ -338,6 +370,7 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
                   options={widthOptions}
                   onChange={(next) => {
                     next === "normal" ? setNormalWidth() : setWideWidth();
+                    restoreEditorFocusSoon();
                   }}
                 />
               </StaticMenuRow>
@@ -345,7 +378,14 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
                 <ValuePill>{currentFontDisplayValue}</ValuePill>
               </ActionMenuRow>
               <StaticMenuRow label="Cursor">
-                <CursorColorControl value={cursorColor} isDarkMode={isDarkMode} onChange={setCursorColor} />
+                <CursorColorControl
+                  value={cursorColor}
+                  isDarkMode={isDarkMode}
+                  onChange={(next) => {
+                    setCursorColor(next);
+                    restoreEditorFocusSoon();
+                  }}
+                />
               </StaticMenuRow>
               <StaticMenuRow label="Editor">
                 <SegmentedControl
@@ -355,6 +395,7 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
                   onChange={(next) => {
                     if (next === editorMode) return;
                     next === "single" ? setSingleMode() : setMultiMode();
+                    restoreEditorFocusSoon();
                   }}
                   variant="text"
                 />
@@ -367,7 +408,10 @@ export const SystemMenu = ({ onOpenHistoryModal }: SystemMenuProps) => {
                   ariaLabel="Task flush"
                   value={taskAutoFlushMode}
                   options={taskFlushOptions}
-                  onChange={setTaskAutoFlushMode}
+                  onChange={(next) => {
+                    setTaskAutoFlushMode(next);
+                    restoreEditorFocusSoon();
+                  }}
                   variant="text"
                 />
               </StaticMenuRow>

--- a/src/page/editor-page.tsx
+++ b/src/page/editor-page.tsx
@@ -13,7 +13,7 @@ import { Link } from "react-router-dom";
 import { EPHE_VERSION } from "../utils/constants";
 import { useCommandK } from "../utils/hooks/use-command-k";
 import { useEditorMode } from "../utils/hooks/use-editor-mode";
-import { useRef, useState, useEffect } from "react";
+import { useCallback, useRef, useState, useEffect } from "react";
 import { useAtom } from "jotai";
 import { HistoryModal } from "../features/history/history-modal";
 import { editorContentAtom } from "../utils/atoms/editor";
@@ -31,6 +31,11 @@ export const EditorPage = () => {
   const singleEditorRef = useRef<SingleEditorRef>(null);
   const [editorContent] = useAtom(editorContentAtom);
   const { isMobile } = useMobileDetector();
+
+  const restoreEditorFocus = useCallback(() => {
+    const view = editorMode === "multi" ? multiEditorRef.current?.view : singleEditorRef.current?.view;
+    view?.focus();
+  }, [editorMode]);
 
   // Unified snapshot restore event handler
   useEffect(() => {
@@ -55,11 +60,7 @@ export const EditorPage = () => {
     // Return focus to editor after closing
     // Use requestAnimationFrame to ensure the menu is fully closed before focusing
     requestAnimationFrame(() => {
-      if (editorMode === "multi" && multiEditorRef.current?.view) {
-        multiEditorRef.current.view.focus();
-      } else if (editorMode === "single" && singleEditorRef.current?.view) {
-        singleEditorRef.current.view.focus();
-      }
+      restoreEditorFocus();
     });
   };
 
@@ -83,7 +84,7 @@ export const EditorPage = () => {
 
         <Footer
           autoHide={true}
-          leftContent={<SystemMenu onOpenHistoryModal={openHistoryModal} />}
+          leftContent={<SystemMenu onOpenHistoryModal={openHistoryModal} onRestoreEditorFocus={restoreEditorFocus} />}
           centerContent={
             isMobile || editorMode === "single" ? null : (
               <DocumentDock onNavigate={(index) => multiEditorRef.current?.navigateToDocument(index)} />


### PR DESCRIPTION
## Summary

- Keep the editor focused when opening the System menu or clicking its controls.
- Restore the active CodeMirror editor focus after System menu setting changes.
- Add an e2e regression test for typing immediately after selecting the System theme control.

## Why

Recent focus-preservation changes were reverted, which left System menu buttons holding focus after clicks. When the user clicked System and changed a setting, keyboard input went to the focused menu button instead of CodeMirror, making the editor appear temporarily unable to accept input.

This PR keeps the System menu non-modal, prevents menu mouse down events from stealing editor focus, and routes setting changes through a small focus-restore callback.

## Validation

- `pnpm exec playwright test e2e/editor.spec.ts --grep "keeps editor input active"`
- `pnpm lint`
- `pnpm build`
- Manual Playwright reproduction confirmed that text typed immediately after Theme > System is inserted into the editor.

Note: `pnpm exec playwright test e2e/editor.spec.ts` was also run; the new regression test passed, but two pre-existing URL tooltip tests failed because `Opt+Click to open link` was not shown.