### PR TITLE
feat: add focus writing mode

### DIFF
--- a/src/features/editor/codemirror/focus-mode.test.ts
+++ b/src/features/editor/codemirror/focus-mode.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { Text } from "@codemirror/state";
+import { getParagraphRange } from "./focus-mode";
+
+const docOf = (content: string) => Text.of(content.split("\n"));
+
+describe("getParagraphRange", () => {
+  it("returns the whole document when there are no blank lines", () => {
+    const doc = docOf("line one\nline two\nline three");
+    expect(getParagraphRange(doc, 0)).toEqual({ from: 0, to: doc.length });
+    expect(getParagraphRange(doc, doc.length)).toEqual({ from: 0, to: doc.length });
+  });
+
+  it("expands to blank-line boundaries", () => {
+    const doc = docOf("first para\n\nsecond line a\nsecond line b\n\nthird para");
+    // Cursor inside "second line a"
+    const pos = doc.line(3).from + 2;
+    const range = getParagraphRange(doc, pos);
+    expect(range.from).toBe(doc.line(3).from);
+    expect(range.to).toBe(doc.line(4).to);
+  });
+
+  it("treats the first paragraph correctly at document start", () => {
+    const doc = docOf("first para\n\nsecond para");
+    const range = getParagraphRange(doc, 3);
+    expect(range.from).toBe(0);
+    expect(range.to).toBe(doc.line(1).to);
+  });
+
+  it("treats the last paragraph correctly at document end", () => {
+    const doc = docOf("first para\n\nlast para");
+    const range = getParagraphRange(doc, doc.length);
+    expect(range.from).toBe(doc.line(3).from);
+    expect(range.to).toBe(doc.length);
+  });
+
+  it("returns the blank line itself when the cursor rests on one", () => {
+    const doc = docOf("first\n\nsecond");
+    const blankLine = doc.line(2);
+    expect(getParagraphRange(doc, blankLine.from)).toEqual({ from: blankLine.from, to: blankLine.to });
+  });
+
+  it("treats whitespace-only lines as paragraph separators", () => {
+    const doc = docOf("first\n   \nsecond");
+    const range = getParagraphRange(doc, doc.line(3).from);
+    expect(range.from).toBe(doc.line(3).from);
+    expect(range.to).toBe(doc.line(3).to);
+  });
+
+  it("keeps a contiguous task list as one block", () => {
+    const doc = docOf("# Today\n- [ ] task a\n- [ ] task b\n\nnotes");
+    const range = getParagraphRange(doc, doc.line(2).from);
+    expect(range.from).toBe(0);
+    expect(range.to).toBe(doc.line(3).to);
+  });
+});

--- a/src/features/editor/codemirror/focus-mode.ts
+++ b/src/features/editor/codemirror/focus-mode.ts
@@ -1,0 +1,85 @@
+import { RangeSetBuilder, type Extension, type Text } from "@codemirror/state";
+import { Decoration, EditorView, ViewPlugin, type DecorationSet, type ViewUpdate } from "@codemirror/view";
+
+export type ParagraphRange = {
+  from: number;
+  to: number;
+};
+
+const isBlankLine = (text: string): boolean => text.trim().length === 0;
+
+/**
+ * Returns the blank-line-delimited block containing `pos`.
+ * A blank line forms its own (empty) range so nothing stays highlighted
+ * while the cursor rests between paragraphs.
+ */
+export const getParagraphRange = (doc: Text, pos: number): ParagraphRange => {
+  const line = doc.lineAt(pos);
+  if (isBlankLine(line.text)) {
+    return { from: line.from, to: line.to };
+  }
+  let first = line.number;
+  while (first > 1 && !isBlankLine(doc.line(first - 1).text)) {
+    first--;
+  }
+  let last = line.number;
+  while (last < doc.lines && !isBlankLine(doc.line(last + 1).text)) {
+    last++;
+  }
+  return { from: doc.line(first).from, to: doc.line(last).to };
+};
+
+const dimLineDecoration = Decoration.line({ class: "cm-focus-dim" });
+
+const buildDimDecorations = (view: EditorView): DecorationSet => {
+  const { state } = view;
+  const paragraph = getParagraphRange(state.doc, state.selection.main.head);
+  const builder = new RangeSetBuilder<Decoration>();
+  for (const { from, to } of view.visibleRanges) {
+    let pos = from;
+    while (pos <= to) {
+      const line = state.doc.lineAt(pos);
+      if (line.to < paragraph.from || line.from > paragraph.to) {
+        builder.add(line.from, line.from, dimLineDecoration);
+      }
+      pos = line.to + 1;
+    }
+  }
+  return builder.finish();
+};
+
+// Rebuilds the dim decorations whenever the caret's paragraph or the visible
+// range changes.
+const focusModePlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = buildDimDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+      if (update.docChanged || update.selectionSet || update.viewportChanged) {
+        this.decorations = buildDimDecorations(update.view);
+      }
+    }
+  },
+  { decorations: (plugin) => plugin.decorations },
+);
+
+const focusModeTheme = EditorView.theme({
+  // Transitions only fire on class toggles of existing lines (paragraph
+  // boundary moves), not on fresh viewport renders — exactly what we want.
+  ".cm-line": {
+    transition: "opacity 200ms ease-out",
+  },
+  ".cm-focus-dim": {
+    opacity: "0.35",
+  },
+});
+
+/**
+ * Focus writing mode: dims everything outside the paragraph being edited so
+ * only the current block stays sharp.
+ */
+export const focusModeExtension: Extension = [focusModePlugin, focusModeTheme];

--- a/src/features/editor/codemirror/use-markdown-editor.ts
+++ b/src/features/editor/codemirror/use-markdown-editor.ts
@@ -23,6 +23,8 @@ import { editorContentAtom } from "../../../utils/atoms/editor";
 import { currentFontValueAtom } from "../../../utils/hooks/use-font";
 import { cursorColorAtom, resolveCursorColor } from "../../../utils/hooks/use-cursor-color";
 import { customCursorLayer } from "./cursor-layer";
+import { useFocusMode } from "../../../utils/hooks/use-focus-mode";
+import { focusModeExtension } from "./focus-mode";
 
 const useMarkdownFormatter = () => {
   const ref = useRef<DprintMarkdownFormatter | null>(null);
@@ -84,8 +86,11 @@ export const useMarkdownEditor = (
   const { editorTheme, editorHighlightStyle } = useEditorTheme(isDarkMode, isWideMode, currentFontValue, cursorColor);
   const { isMobile } = useMobileDetector();
 
+  const { isFocusMode } = useFocusMode();
+
   const themeCompartment = useRef(new Compartment()).current;
   const highlightCompartment = useRef(new Compartment()).current;
+  const focusModeCompartment = useRef(new Compartment()).current;
 
   // Tracks the last value the editor itself pushed into `content`. When the
   // sync effect below sees `content` equal this ref, it knows the value is its
@@ -219,6 +224,7 @@ export const useMarkdownEditor = (
 
         themeCompartment.of(editorTheme),
         highlightCompartment.of(editorHighlightStyle),
+        focusModeCompartment.of(isFocusMode ? focusModeExtension : []),
         // Only show placeholder on non-mobile devices
         ...(isMobile ? [] : [placeholder(getRandomQuote())]),
 
@@ -261,6 +267,15 @@ export const useMarkdownEditor = (
       effects: [themeCompartment.reconfigure(editorTheme), highlightCompartment.reconfigure(editorHighlightStyle)],
     });
   }, [highlightCompartment.reconfigure, themeCompartment.reconfigure, editorTheme, editorHighlightStyle]);
+
+  // Toggle focus mode (paragraph dimming)
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: focusModeCompartment.reconfigure(isFocusMode ? focusModeExtension : []),
+    });
+  }, [focusModeCompartment.reconfigure, isFocusMode]);
 
   // Listen for external content updates
   // - text edit emits storage event

--- a/src/features/menu/command-menu.tsx
+++ b/src/features/menu/command-menu.tsx
@@ -26,8 +26,10 @@ import {
   TextAaIcon,
   NotebookIcon,
   GithubLogoIcon,
+  CrosshairSimpleIcon,
 } from "@phosphor-icons/react";
 import { snapshotStorage } from "../snapshots/snapshot-storage";
+import { useFocusMode } from "../../utils/hooks/use-focus-mode";
 import { useAtom } from "jotai";
 
 // Custom hook for markdown formatter
@@ -65,7 +67,7 @@ type CommandItem = {
   perform: () => void;
 };
 
-const INTERFACE_IDS = new Set(["theme-toggle", "paper-mode", "editor-width", "font-family"]);
+const INTERFACE_IDS = new Set(["theme-toggle", "paper-mode", "editor-width", "font-family", "focus-mode"]);
 const OPERATION_IDS = new Set([
   "export-markdown",
   "format-document",
@@ -91,6 +93,7 @@ export const CommandMenu = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const [fontFamily, setFontFamily] = useAtom(fontFamilyAtom);
+  const { focusMode, toggleFocusMode } = useFocusMode();
 
   useEffect(() => {
     if (!open) {
@@ -126,6 +129,11 @@ export const CommandMenu = ({
 
   const toggleEditorWidthThenClose = () => {
     toggleEditorWidth();
+    onClose();
+  };
+
+  const toggleFocusModeThenClose = () => {
+    toggleFocusMode();
     onClose();
   };
 
@@ -332,6 +340,13 @@ export const CommandMenu = ({
       icon: <TextAaIcon className="size-4" weight="light" />, // changed from FileText
       perform: cycleFont,
     });
+
+    list.push({
+      id: "focus-mode",
+      name: "Toggle focus mode",
+      icon: <CrosshairSimpleIcon className="size-4" weight="light" />,
+      perform: toggleFocusModeThenClose,
+    });
     list.push({
       id: "export-markdown",
       name: "Export markdown",
@@ -470,6 +485,11 @@ export const CommandMenu = ({
                               {command.id === "font-family" && (
                                 <span className="ml-1.5 text-neutral-500 text-xs dark:text-neutral-400">
                                   ({FONT_FAMILIES[fontFamily].displayValue})
+                                </span>
+                              )}
+                              {command.id === "focus-mode" && (
+                                <span className="ml-1.5 text-neutral-500 text-xs dark:text-neutral-400">
+                                  ({focusMode})
                                 </span>
                               )}
                             </span>

--- a/src/features/menu/system-menu.tsx
+++ b/src/features/menu/system-menu.tsx
@@ -28,6 +28,7 @@ import {
 import { taskStorage } from "../editor/tasks/task-storage";
 import { snapshotStorage } from "../snapshots/snapshot-storage";
 import { useTaskAutoFlush, type TaskAutoFlushMode } from "../../utils/hooks/use-task-auto-flush";
+import { useFocusMode, type FocusMode } from "../../utils/hooks/use-focus-mode";
 import { useAtom, useAtomValue } from "jotai";
 
 const cx = (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(" ");
@@ -243,6 +244,7 @@ export const SystemMenu = ({ onOpenHistoryModal, onRestoreEditorFocus }: SystemM
   const { todayCompletedTasks } = useTodayCompletedTasks(menuOpen);
   const { snapshotCount } = useSnapshotCount(menuOpen);
   const { taskAutoFlushMode, setTaskAutoFlushMode } = useTaskAutoFlush();
+  const { focusMode, setFocusMode } = useFocusMode();
 
   const themeOptions: Array<SegmentOption<ColorTheme>> = [
     { value: COLOR_THEME.LIGHT, label: "Light", icon: <SunIcon className="size-4" weight="regular" /> },
@@ -269,6 +271,11 @@ export const SystemMenu = ({ onOpenHistoryModal, onRestoreEditorFocus }: SystemM
   const taskFlushOptions: Array<SegmentOption<TaskAutoFlushMode>> = [
     { value: "off", label: "Off" },
     { value: "instant", label: "On" },
+  ];
+
+  const focusModeOptions: Array<SegmentOption<FocusMode>> = [
+    { value: "off", label: "Off" },
+    { value: "on", label: "On" },
   ];
 
   const openTaskSnapshotModal = (tabIndex: number) => {
@@ -385,6 +392,18 @@ export const SystemMenu = ({ onOpenHistoryModal, onRestoreEditorFocus }: SystemM
                     setCursorColor(next);
                     restoreEditorFocusSoon();
                   }}
+                />
+              </StaticMenuRow>
+              <StaticMenuRow label="Focus">
+                <SegmentedControl
+                  ariaLabel="Focus mode"
+                  value={focusMode}
+                  options={focusModeOptions}
+                  onChange={(next) => {
+                    setFocusMode(next);
+                    restoreEditorFocusSoon();
+                  }}
+                  variant="text"
                 />
               </StaticMenuRow>
               <StaticMenuRow label="Editor">

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -8,6 +8,7 @@ export const LOCAL_STORAGE_KEYS = {
   PREVIEW_MODE: "ephe:preview-mode",
   TOC_MODE: "ephe:toc-mode",
   TASK_AUTO_FLUSH_MODE: "ephe:task-auto-flush-mode",
+  FOCUS_MODE: "ephe:focus-mode",
   FONT_FAMILY: "ephe:font-family",
   CURSOR_COLOR: "ephe:cursor-color",
   CURSOR_POSITION: "ephe:cursor-position",

--- a/src/utils/hooks/use-focus-mode.ts
+++ b/src/utils/hooks/use-focus-mode.ts
@@ -1,0 +1,24 @@
+import { atomWithStorage } from "jotai/utils";
+import { LOCAL_STORAGE_KEYS } from "../constants";
+import { useAtom } from "jotai";
+
+export type FocusMode = "off" | "on";
+
+export const focusModeAtom = atomWithStorage<FocusMode>(LOCAL_STORAGE_KEYS.FOCUS_MODE, "off");
+
+export const useFocusMode = () => {
+  const [focusMode, setFocusMode] = useAtom(focusModeAtom);
+
+  const toggleFocusMode = () => {
+    const next: FocusMode = focusMode === "on" ? "off" : "on";
+    setFocusMode(next);
+    return next;
+  };
+
+  return {
+    focusMode,
+    isFocusMode: focusMode === "on",
+    setFocusMode,
+    toggleFocusMode,
+  };
+};


### PR DESCRIPTION
## What

Adds an opt-in focus writing mode to make ephe a calmer place to think:

Paragraph dimming: lines outside the paragraph under the cursor fade to 35% opacity (with a soft 200ms transition), so only what you're working on stays sharp. The rest of the page stays put — no scrolling or motion.

Toggle it from:
- System menu → Focus row (Off / On)
- Command menu (⌘K) → Toggle focus mode

The setting persists in localStorage.

## How

- New CodeMirror 6 extension `focus-mode.ts`: a `ViewPlugin` marks every line outside the caret's paragraph with a `.cm-focus-dim` line decoration, rebuilt when the caret's paragraph or the visible range changes.
  - "Paragraph" = a blank-line-delimited block (`getParagraphRange`); a blank line is its own empty range so nothing stays lit while the caret rests between paragraphs.
  - Dimming is pure CSS opacity on a class, so the 200ms fade only fires on paragraph-boundary changes, not on fresh viewport renders.
- `use-focus-mode` hook stores the toggle via `atomWithStorage`, matching the existing `use-paper-mode` / `use-task-auto-flush` pattern.
- Wired into the editor through a dedicated CodeMirror `Compartment`, reconfigured on toggle.

## Testing

- Unit tests for `getParagraphRange` (blank-line boundary detection, doc start/end, task-list blocks) — 7 cases.
- Manually verified in-browser: the cursor paragraph stays at opacity 1.0 while every other line reads 0.35; dimming follows the caret across paragraphs; typing does **not** scroll or recenter the page; the ⌘K command toggles; the setting survives reload.
- `tsc`, full unit suite (152 tests), Biome, and ESLint all pass.

## Notes

Scoped to the focus-mode feature only (no design-system changes). The two menu files are based on the current `main`; when the design-system extraction lands, whichever merges second needs a small rebase on those two files.