### PR TITLE
feat: add inline calculator and date/time insert commands

### DIFF
--- a/src/features/editor/codemirror/calc/calc-document.test.ts
+++ b/src/features/editor/codemirror/calc/calc-document.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+import { evaluateCalcDocument, formatCalcValue } from "./calc-document";
+
+const evaluate = (text: string) => evaluateCalcDocument(text.split("\n"));
+
+describe("evaluateCalcDocument", () => {
+  test("shows results for expression lines", () => {
+    const results = evaluate("12 * 4");
+    expect(results).toEqual([{ index: 0, value: 48 }]);
+  });
+
+  test("skips plain text and bare numbers", () => {
+    expect(evaluate("just some words")).toEqual([]);
+    expect(evaluate("42")).toEqual([]);
+    expect(evaluate("3.14")).toEqual([]);
+  });
+
+  test("a trailing = forces a result even for bare values", () => {
+    const results = evaluate("42 =");
+    expect(results).toEqual([{ index: 0, value: 42 }]);
+  });
+
+  test("assignments define reactive variables", () => {
+    const results = evaluate(["price = 1200", "qty = 3", "price * qty"].join("\n"));
+    expect(results).toEqual([{ index: 2, value: 3600 }]);
+  });
+
+  test("assignments with computed right-hand side show their value", () => {
+    const results = evaluate(["base = 100", "total = base * 1.1"].join("\n"));
+    expect(results).toEqual([{ index: 1, value: expect.closeTo(110) }]);
+  });
+
+  test("sum aggregates the block above, including plain-text amounts", () => {
+    const doc = ["coffee 4.50", "bagel 3.25", "- [ ] tip 2", "sum"].join("\n");
+    const results = evaluate(doc);
+    expect(results).toEqual([{ index: 3, value: 9.75 }]);
+  });
+
+  test("average works and blank lines bound the block", () => {
+    const doc = ["10", "20", "", "30", "40", "average"].join("\n");
+    const results = evaluate(doc);
+    expect(results).toEqual([{ index: 5, value: 35 }]);
+  });
+
+  test("sum ignores lines without numbers and has no result on empty blocks", () => {
+    expect(evaluate(["no numbers here", "sum"].join("\n"))).toEqual([]);
+    const results = evaluate(["5", "words only", "7", "total"].join("\n"));
+    expect(results).toEqual([{ index: 3, value: 12 }]);
+  });
+
+  test("evaluates inside markdown list items and quotes", () => {
+    const results = evaluate(["- 2 * 3", "> 10 / 2"].join("\n"));
+    expect(results).toEqual([
+      { index: 0, value: 6 },
+      { index: 1, value: 5 },
+    ]);
+  });
+
+  test("skips fenced code blocks", () => {
+    const doc = ["```", "1 + 1", "```", "2 + 2"].join("\n");
+    const results = evaluate(doc);
+    expect(results).toEqual([{ index: 3, value: 4 }]);
+  });
+
+  test("skips date-like and time-like lines", () => {
+    expect(evaluate("2026-07-04")).toEqual([]);
+    expect(evaluate("meeting at 12:30")).toEqual([]);
+    expect(evaluate("7/4/2026")).toEqual([]);
+  });
+
+  test("variables persist across blocks but sums do not cross blank lines", () => {
+    const doc = ["x = 10", "", "x * 2"].join("\n");
+    const results = evaluate(doc);
+    expect(results).toEqual([{ index: 2, value: 20 }]);
+  });
+
+  test("aggregate lines do not feed later aggregates", () => {
+    const doc = ["1", "2", "sum", "sum"].join("\n");
+    const results = evaluate(doc);
+    expect(results).toEqual([
+      { index: 2, value: 3 },
+      { index: 3, value: 3 },
+    ]);
+  });
+
+  test("division by zero produces no result", () => {
+    expect(evaluate("1 / 0")).toEqual([]);
+  });
+});
+
+describe("formatCalcValue", () => {
+  test("trims floating point noise", () => {
+    expect(formatCalcValue(0.1 + 0.2)).toBe("0.3");
+  });
+
+  test("keeps small values", () => {
+    expect(formatCalcValue(0.000125)).toBe("0.000125");
+  });
+
+  test("limits long decimals", () => {
+    expect(formatCalcValue(100 / 3)).toBe("33.333333");
+  });
+});

--- a/src/features/editor/codemirror/calc/calc-document.ts
+++ b/src/features/editor/codemirror/calc/calc-document.ts
@@ -1,0 +1,130 @@
+import { evaluateExpression } from "./expression";
+
+/**
+ * Document-level evaluation for the inline calculator (inspired by Antinote):
+ * - Expression lines ("12 * 4") show their result inline.
+ * - Assignment lines ("price = 1200") define reactive variables usable below.
+ * - Keyword lines ("sum" / "total" / "avg" / "average") aggregate the
+ *   blank-line-delimited block of lines directly above, picking up evaluated
+ *   results and trailing numbers in plain-text lines ("coffee 4.50").
+ */
+
+export type CalcLineResult = {
+  /** 0-based line index in the evaluated document. */
+  index: number;
+  value: number;
+};
+
+const AGGREGATE_PATTERN = /^(sum|total|avg|average)\s*[:=]?\s*$/i;
+const ASSIGNMENT_PATTERN = /^([A-Za-z_][A-Za-z0-9_]*)\s*=(?!=)\s*(\S.*)$/;
+const CODE_FENCE_PATTERN = /^\s*(```|~~~)/;
+// Dates ("2026-07-04", "7/4") and clock times ("12:30") parse as arithmetic
+// but never mean it — skip such lines entirely.
+const DATE_OR_TIME_PATTERN = /\d{1,4}[-/.]\d{1,2}[-/.]\d{1,4}|\d{1,2}:\d{2}/;
+// A widget is only shown when the line actually computes something.
+const CONTAINS_OPERATOR_PATTERN = /[+\-*/%^(]/;
+const BARE_NUMBER_PATTERN = /^[-+]?[$€£¥]?\d[\d,]*(\.\d+)?$/;
+const NUMBER_IN_TEXT_PATTERN = /-?\d[\d,]*(?:\.\d+)?/g;
+const QUOTE_PREFIX_PATTERN = /^(?:>\s*)+/;
+const HEADING_PREFIX_PATTERN = /^#{1,6}\s+/;
+const LIST_PREFIX_PATTERN = /^[-*+]\s+(?:\[[ xX]\]\s+)?/;
+const ORDERED_LIST_PREFIX_PATTERN = /^\d+[.)]\s+/;
+
+/** Removes leading markdown syntax so list items and quotes can hold math. */
+const stripMarkdownPrefix = (line: string): string =>
+  line
+    .trim()
+    .replace(QUOTE_PREFIX_PATTERN, "")
+    .replace(HEADING_PREFIX_PATTERN, "")
+    .replace(LIST_PREFIX_PATTERN, "")
+    .replace(ORDERED_LIST_PREFIX_PATTERN, "")
+    .trim();
+
+/** Last number in a plain-text line ("coffee 4.50" → 4.5), or null. */
+const extractTrailingNumber = (text: string): number | null => {
+  const matches = text.match(NUMBER_IN_TEXT_PATTERN);
+  if (!matches) return null;
+  const value = Number.parseFloat(matches[matches.length - 1].replaceAll(",", ""));
+  return Number.isFinite(value) ? value : null;
+};
+
+export const formatCalcValue = (value: number): string => {
+  // Trim float noise (0.1 + 0.2) without collapsing small values to 0.
+  const rounded = Math.abs(value) >= 1 ? Math.round(value * 1e6) / 1e6 : Number(value.toPrecision(6));
+  return String(rounded);
+};
+
+export const evaluateCalcDocument = (lines: readonly string[]): CalcLineResult[] => {
+  const variables = new Map<string, number>();
+  const results: CalcLineResult[] = [];
+  // Running total of the current blank-line-delimited block, read by
+  // aggregate keyword lines. Aggregates themselves never contribute.
+  let blockSum = 0;
+  let blockCount = 0;
+  let insideCodeFence = false;
+
+  const pushResult = (index: number, value: number) => {
+    if (!Number.isFinite(value)) return;
+    results.push({ index, value });
+  };
+
+  const contribute = (value: number | null) => {
+    if (value === null) return;
+    blockSum += value;
+    blockCount++;
+  };
+
+  lines.forEach((rawLine, index) => {
+    if (rawLine.trim().length === 0) {
+      blockSum = 0;
+      blockCount = 0;
+      return;
+    }
+    if (CODE_FENCE_PATTERN.test(rawLine)) {
+      insideCodeFence = !insideCodeFence;
+      return;
+    }
+    if (insideCodeFence) return;
+
+    const text = stripMarkdownPrefix(rawLine);
+    if (text.length === 0 || DATE_OR_TIME_PATTERN.test(text)) return;
+
+    const aggregate = text.match(AGGREGATE_PATTERN);
+    if (aggregate) {
+      if (blockCount === 0) return;
+      const keyword = aggregate[1].toLowerCase();
+      pushResult(index, keyword === "avg" || keyword === "average" ? blockSum / blockCount : blockSum);
+      return;
+    }
+
+    const assignment = text.match(ASSIGNMENT_PATTERN);
+    if (assignment) {
+      const [, name, rhs] = assignment;
+      const value = evaluateExpression(rhs, variables);
+      if (value === null) return;
+      variables.set(name, value);
+      contribute(value);
+      // "x = 5" needs no echo; "x = 5 * 3" does.
+      if (!BARE_NUMBER_PATTERN.test(rhs.trim())) pushResult(index, value);
+      return;
+    }
+
+    // A trailing "=" is an explicit request: always show the result.
+    const explicit = text.endsWith("=");
+    const expressionText = explicit ? text.slice(0, -1).trimEnd() : text;
+    if (expressionText.length === 0) return;
+
+    const value = evaluateExpression(expressionText, variables);
+    if (value === null) {
+      // Not math, but a plain-text line like "coffee 4.50" still feeds `sum`.
+      contribute(extractTrailingNumber(text));
+      return;
+    }
+    contribute(value);
+    if (explicit || (CONTAINS_OPERATOR_PATTERN.test(expressionText) && !BARE_NUMBER_PATTERN.test(expressionText))) {
+      pushResult(index, value);
+    }
+  });
+
+  return results;
+};

--- a/src/features/editor/codemirror/calc/expression.test.ts
+++ b/src/features/editor/codemirror/calc/expression.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import { evaluateExpression } from "./expression";
+
+describe("evaluateExpression", () => {
+  test("evaluates basic arithmetic", () => {
+    expect(evaluateExpression("1 + 2")).toBe(3);
+    expect(evaluateExpression("10 - 4")).toBe(6);
+    expect(evaluateExpression("6 * 7")).toBe(42);
+    expect(evaluateExpression("15 / 4")).toBe(3.75);
+    expect(evaluateExpression("10 % 3")).toBe(1);
+  });
+
+  test("respects operator precedence", () => {
+    expect(evaluateExpression("2 + 3 * 4")).toBe(14);
+    expect(evaluateExpression("(2 + 3) * 4")).toBe(20);
+    expect(evaluateExpression("2 * 3 + 4 * 5")).toBe(26);
+  });
+
+  test("exponent is right-associative and binds tighter than unary", () => {
+    expect(evaluateExpression("2 ^ 3")).toBe(8);
+    expect(evaluateExpression("2 ^ 3 ^ 2")).toBe(512);
+    expect(evaluateExpression("-2 ^ 2")).toBe(-4);
+  });
+
+  test("handles unary signs", () => {
+    expect(evaluateExpression("-5 + 10")).toBe(5);
+    expect(evaluateExpression("--5")).toBe(5);
+    expect(evaluateExpression("+5")).toBe(5);
+  });
+
+  test("supports functions", () => {
+    expect(evaluateExpression("sqrt(16)")).toBe(4);
+    expect(evaluateExpression("abs(-3)")).toBe(3);
+    expect(evaluateExpression("round(2.6)")).toBe(3);
+    expect(evaluateExpression("floor(2.6)")).toBe(2);
+    expect(evaluateExpression("ceil(2.1)")).toBe(3);
+    expect(evaluateExpression("min(3, 1, 2)")).toBe(1);
+    expect(evaluateExpression("max(3, 1, 2)")).toBe(3);
+  });
+
+  test("supports constants", () => {
+    expect(evaluateExpression("pi")).toBeCloseTo(Math.PI);
+    expect(evaluateExpression("e ^ 2")).toBeCloseTo(Math.E ** 2);
+  });
+
+  test("resolves variables", () => {
+    const variables = new Map([
+      ["price", 1200],
+      ["qty", 3],
+    ]);
+    expect(evaluateExpression("price * qty", variables)).toBe(3600);
+  });
+
+  test("user variables shadow constants", () => {
+    expect(evaluateExpression("e + 1", new Map([["e", 10]]))).toBe(11);
+  });
+
+  test("accepts currency symbols and grouped thousands", () => {
+    expect(evaluateExpression("$1,200 * 3")).toBe(3600);
+    expect(evaluateExpression("¥1,000 + ¥500")).toBe(1500);
+  });
+
+  test("keeps comma as argument separator when spaced", () => {
+    expect(evaluateExpression("min(1, 200)")).toBe(1);
+    // Without a space the thousands-group reading wins: min(1200).
+    expect(evaluateExpression("min(1,200)")).toBe(1200);
+  });
+
+  test("returns null for invalid input", () => {
+    expect(evaluateExpression("")).toBeNull();
+    expect(evaluateExpression("hello world")).toBeNull();
+    expect(evaluateExpression("1 +")).toBeNull();
+    expect(evaluateExpression("(1 + 2")).toBeNull();
+    expect(evaluateExpression("1 + unknown")).toBeNull();
+    expect(evaluateExpression("2 items + 3")).toBeNull();
+  });
+
+  test("returns null for non-finite results", () => {
+    expect(evaluateExpression("1 / 0")).toBeNull();
+    expect(evaluateExpression("0 / 0")).toBeNull();
+  });
+});

--- a/src/features/editor/codemirror/calc/expression.ts
+++ b/src/features/editor/codemirror/calc/expression.ts
@@ -1,0 +1,207 @@
+/**
+ * Arithmetic expression evaluator for the inline calculator.
+ * Hand-rolled recursive descent parser: no eval(), no dependencies,
+ * so arbitrary note content can never execute code.
+ *
+ * Grammar:
+ *   expression := term (("+" | "-") term)*
+ *   term       := unary (("*" | "/" | "%") unary)*
+ *   unary      := ("-" | "+") unary | exponent    so -2^2 = -(2^2) = -4
+ *   exponent   := primary ("^" unary)?            right-associative
+ *   primary    := number | name | name "(" args ")" | "(" expression ")"
+ */
+
+export type Variables = ReadonlyMap<string, number>;
+
+type Token = { type: "number"; value: number } | { type: "name"; name: string } | { type: "op"; op: string };
+
+// "1,200.50" — comma-grouped numbers must be matched before plain numbers so
+// the comma is not consumed as a function-argument separator.
+const GROUPED_NUMBER_PATTERN = /^\d{1,3}(?:,\d{3})+(?:\.\d+)?/;
+const NUMBER_PATTERN = /^(?:\d+(?:\.\d+)?|\.\d+)/;
+const NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*/;
+const OPERATOR_CHARS = new Set(["+", "-", "*", "/", "%", "^", "(", ")", ","]);
+// Currency symbols read naturally in notes ("$1,200 * 3") without changing the math.
+const IGNORED_CHARS = new Set(["$", "€", "£", "¥", " ", "\t"]);
+
+const CONSTANTS: ReadonlyMap<string, number> = new Map([
+  ["pi", Math.PI],
+  ["e", Math.E],
+]);
+
+const FUNCTIONS: ReadonlyMap<string, (args: number[]) => number | null> = new Map([
+  ["sqrt", (args) => (args.length === 1 ? Math.sqrt(args[0]) : null)],
+  ["abs", (args) => (args.length === 1 ? Math.abs(args[0]) : null)],
+  ["round", (args) => (args.length === 1 ? Math.round(args[0]) : null)],
+  ["floor", (args) => (args.length === 1 ? Math.floor(args[0]) : null)],
+  ["ceil", (args) => (args.length === 1 ? Math.ceil(args[0]) : null)],
+  ["min", (args) => (args.length > 0 ? Math.min(...args) : null)],
+  ["max", (args) => (args.length > 0 ? Math.max(...args) : null)],
+]);
+
+const tokenize = (input: string): Token[] | null => {
+  const tokens: Token[] = [];
+  let rest = input;
+  while (rest.length > 0) {
+    const char = rest[0];
+    if (IGNORED_CHARS.has(char)) {
+      rest = rest.slice(1);
+      continue;
+    }
+    const grouped = rest.match(GROUPED_NUMBER_PATTERN);
+    if (grouped) {
+      tokens.push({ type: "number", value: Number.parseFloat(grouped[0].replaceAll(",", "")) });
+      rest = rest.slice(grouped[0].length);
+      continue;
+    }
+    const number = rest.match(NUMBER_PATTERN);
+    if (number) {
+      tokens.push({ type: "number", value: Number.parseFloat(number[0]) });
+      rest = rest.slice(number[0].length);
+      continue;
+    }
+    const name = rest.match(NAME_PATTERN);
+    if (name) {
+      tokens.push({ type: "name", name: name[0] });
+      rest = rest.slice(name[0].length);
+      continue;
+    }
+    if (OPERATOR_CHARS.has(char)) {
+      tokens.push({ type: "op", op: char });
+      rest = rest.slice(1);
+      continue;
+    }
+    return null;
+  }
+  return tokens;
+};
+
+class ParseError extends Error {}
+
+class Parser {
+  private position = 0;
+
+  constructor(
+    private readonly tokens: Token[],
+    private readonly variables: Variables,
+  ) {}
+
+  parse(): number {
+    const value = this.expression();
+    if (this.position < this.tokens.length) {
+      throw new ParseError("unconsumed input");
+    }
+    return value;
+  }
+
+  private peek(): Token | undefined {
+    return this.tokens[this.position];
+  }
+
+  private takeOp(...ops: string[]): string | null {
+    const token = this.peek();
+    if (token?.type === "op" && ops.includes(token.op)) {
+      this.position++;
+      return token.op;
+    }
+    return null;
+  }
+
+  private expression(): number {
+    let value = this.term();
+    let op = this.takeOp("+", "-");
+    while (op) {
+      const right = this.term();
+      value = op === "+" ? value + right : value - right;
+      op = this.takeOp("+", "-");
+    }
+    return value;
+  }
+
+  private term(): number {
+    let value = this.unary();
+    let op = this.takeOp("*", "/", "%");
+    while (op) {
+      const right = this.unary();
+      value = op === "*" ? value * right : op === "/" ? value / right : value % right;
+      op = this.takeOp("*", "/", "%");
+    }
+    return value;
+  }
+
+  private unary(): number {
+    const op = this.takeOp("-", "+");
+    if (op) {
+      const value = this.unary();
+      return op === "-" ? -value : value;
+    }
+    return this.exponent();
+  }
+
+  private exponent(): number {
+    const base = this.primary();
+    if (this.takeOp("^")) {
+      return base ** this.unary();
+    }
+    return base;
+  }
+
+  private primary(): number {
+    const token = this.peek();
+    if (token === undefined) {
+      throw new ParseError("unexpected end of input");
+    }
+    if (token.type === "number") {
+      this.position++;
+      return token.value;
+    }
+    if (token.type === "name") {
+      this.position++;
+      const fn = FUNCTIONS.get(token.name.toLowerCase());
+      if (fn && this.takeOp("(")) {
+        const args = [this.expression()];
+        while (this.takeOp(",")) {
+          args.push(this.expression());
+        }
+        if (!this.takeOp(")")) {
+          throw new ParseError("missing closing paren");
+        }
+        const value = fn(args);
+        if (value === null) {
+          throw new ParseError("invalid arguments");
+        }
+        return value;
+      }
+      const variable = this.variables.get(token.name) ?? CONSTANTS.get(token.name.toLowerCase());
+      if (variable === undefined) {
+        throw new ParseError(`unknown name: ${token.name}`);
+      }
+      return variable;
+    }
+    if (this.takeOp("(")) {
+      const value = this.expression();
+      if (!this.takeOp(")")) {
+        throw new ParseError("missing closing paren");
+      }
+      return value;
+    }
+    throw new ParseError(`unexpected token: ${token.op}`);
+  }
+}
+
+/**
+ * Evaluates an arithmetic expression. Returns null when the input is not a
+ * valid, fully-consumable expression or the result is not a finite number —
+ * callers treat null as "this line is not math".
+ */
+export const evaluateExpression = (input: string, variables: Variables = new Map()): number | null => {
+  const tokens = tokenize(input);
+  if (tokens === null || tokens.length === 0) return null;
+  try {
+    const value = new Parser(tokens, variables).parse();
+    return Number.isFinite(value) ? value : null;
+  } catch (error) {
+    if (error instanceof ParseError) return null;
+    throw error;
+  }
+};

--- a/src/features/editor/codemirror/calc/index.ts
+++ b/src/features/editor/codemirror/calc/index.ts
@@ -1,0 +1,83 @@
+import { RangeSetBuilder, type Extension } from "@codemirror/state";
+import { Decoration, EditorView, ViewPlugin, WidgetType, type DecorationSet, type ViewUpdate } from "@codemirror/view";
+import { evaluateCalcDocument, formatCalcValue } from "./calc-document";
+
+class CalcResultWidget extends WidgetType {
+  constructor(private readonly formatted: string) {
+    super();
+  }
+
+  eq(other: CalcResultWidget): boolean {
+    return other.formatted === this.formatted;
+  }
+
+  toDOM(): HTMLElement {
+    const dom = document.createElement("span");
+    dom.className = "cm-calc-result";
+    dom.textContent = `= ${this.formatted}`;
+    dom.title = "Click to copy";
+    dom.setAttribute("aria-hidden", "true");
+    dom.addEventListener("mousedown", (event) => {
+      // preventDefault keeps the editor selection (and focus) untouched.
+      event.preventDefault();
+      void navigator.clipboard?.writeText(this.formatted);
+      dom.textContent = "copied";
+      setTimeout(() => {
+        dom.textContent = `= ${this.formatted}`;
+      }, 800);
+    });
+    return dom;
+  }
+}
+
+const buildCalcDecorations = (view: EditorView): DecorationSet => {
+  const doc = view.state.doc;
+  // Variables and aggregates depend on lines above, so the whole document is
+  // evaluated even though only visible lines end up decorated.
+  const lines = doc.toString().split("\n");
+  const builder = new RangeSetBuilder<Decoration>();
+  for (const result of evaluateCalcDocument(lines)) {
+    const line = doc.line(result.index + 1);
+    const widget = new CalcResultWidget(formatCalcValue(result.value));
+    builder.add(line.to, line.to, Decoration.widget({ widget, side: 1 }));
+  }
+  return builder.finish();
+};
+
+const inlineCalcPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = buildCalcDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+      if (update.docChanged) {
+        this.decorations = buildCalcDecorations(update.view);
+      }
+    }
+  },
+  { decorations: (plugin) => plugin.decorations },
+);
+
+// opacity + currentColor keep the widget legible in both light and dark themes.
+const inlineCalcTheme = EditorView.baseTheme({
+  ".cm-calc-result": {
+    marginLeft: "0.75em",
+    padding: "0.05em 0.45em",
+    borderRadius: "4px",
+    fontSize: "0.85em",
+    backgroundColor: "rgba(125, 125, 125, 0.14)",
+    opacity: "0.75",
+    cursor: "pointer",
+    userSelect: "none",
+    webkitUserSelect: "none",
+  },
+});
+
+/**
+ * Inline calculator: evaluates math lines, variable assignments, and
+ * sum/average keywords, rendering results at the end of the line.
+ */
+export const inlineCalcExtension: Extension = [inlineCalcPlugin, inlineCalcTheme];

--- a/src/features/editor/codemirror/calc/inline-calc.browser.test.ts
+++ b/src/features/editor/codemirror/calc/inline-calc.browser.test.ts
@@ -1,0 +1,47 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { describe, expect, test } from "vitest";
+import { inlineCalcExtension } from "./index";
+
+const createViewFromText = (text: string): EditorView => {
+  const state = EditorState.create({
+    doc: text,
+    extensions: [inlineCalcExtension],
+  });
+  const view = new EditorView({ state });
+  document.body.appendChild(view.dom);
+  return view;
+};
+
+const resultTexts = (view: EditorView): string[] =>
+  Array.from(view.dom.querySelectorAll(".cm-calc-result")).map((el) => el.textContent ?? "");
+
+describe("inlineCalcExtension", () => {
+  test("renders a result widget for math lines", () => {
+    const view = createViewFromText("12 * 4");
+    expect(resultTexts(view)).toEqual(["= 48"]);
+    view.destroy();
+  });
+
+  test("does not decorate plain text", () => {
+    const view = createViewFromText("just a note about 3 things");
+    expect(resultTexts(view)).toEqual([]);
+    view.destroy();
+  });
+
+  test("updates results when the document changes", () => {
+    const view = createViewFromText("1 + 1");
+    expect(resultTexts(view)).toEqual(["= 2"]);
+
+    view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: "2 + 3" } });
+    expect(resultTexts(view)).toEqual(["= 5"]);
+    view.destroy();
+  });
+
+  test("supports variables and sum across lines", () => {
+    // sum collects the whole block above: 1200 (assignment) + 2400 + 10 + 20.
+    const view = createViewFromText(["price = 1200", "price * 2", "10", "20", "sum"].join("\n"));
+    expect(resultTexts(view)).toEqual(["= 2400", "= 3630"]);
+    view.destroy();
+  });
+});

--- a/src/features/editor/codemirror/use-markdown-editor.ts
+++ b/src/features/editor/codemirror/use-markdown-editor.ts
@@ -25,6 +25,8 @@ import { cursorColorAtom, resolveCursorColor } from "../../../utils/hooks/use-cu
 import { customCursorLayer } from "./cursor-layer";
 import { useFocusMode } from "../../../utils/hooks/use-focus-mode";
 import { focusModeExtension } from "./focus-mode";
+import { useInlineCalc } from "../../../utils/hooks/use-inline-calc";
+import { inlineCalcExtension } from "./calc";
 
 const useMarkdownFormatter = () => {
   const ref = useRef<DprintMarkdownFormatter | null>(null);
@@ -87,10 +89,12 @@ export const useMarkdownEditor = (
   const { isMobile } = useMobileDetector();
 
   const { isFocusMode } = useFocusMode();
+  const { isInlineCalcEnabled } = useInlineCalc();
 
   const themeCompartment = useRef(new Compartment()).current;
   const highlightCompartment = useRef(new Compartment()).current;
   const focusModeCompartment = useRef(new Compartment()).current;
+  const inlineCalcCompartment = useRef(new Compartment()).current;
 
   // Tracks the last value the editor itself pushed into `content`. When the
   // sync effect below sees `content` equal this ref, it knows the value is its
@@ -225,6 +229,7 @@ export const useMarkdownEditor = (
         themeCompartment.of(editorTheme),
         highlightCompartment.of(editorHighlightStyle),
         focusModeCompartment.of(isFocusMode ? focusModeExtension : []),
+        inlineCalcCompartment.of(isInlineCalcEnabled ? inlineCalcExtension : []),
         // Only show placeholder on non-mobile devices
         ...(isMobile ? [] : [placeholder(getRandomQuote())]),
 
@@ -276,6 +281,15 @@ export const useMarkdownEditor = (
       effects: focusModeCompartment.reconfigure(isFocusMode ? focusModeExtension : []),
     });
   }, [focusModeCompartment.reconfigure, isFocusMode]);
+
+  // Toggle inline calculator (math results at line ends)
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: inlineCalcCompartment.reconfigure(isInlineCalcEnabled ? inlineCalcExtension : []),
+    });
+  }, [inlineCalcCompartment.reconfigure, isInlineCalcEnabled]);
 
   // Listen for external content updates
   // - text edit emits storage event

--- a/src/features/menu/command-menu.tsx
+++ b/src/features/menu/command-menu.tsx
@@ -27,9 +27,14 @@ import {
   NotebookIcon,
   GithubLogoIcon,
   CrosshairSimpleIcon,
+  CalculatorIcon,
+  CalendarBlankIcon,
+  ClockIcon,
 } from "@phosphor-icons/react";
 import { snapshotStorage } from "../snapshots/snapshot-storage";
+import { formatDateKey } from "../../utils/storage";
 import { useFocusMode } from "../../utils/hooks/use-focus-mode";
+import { useInlineCalc } from "../../utils/hooks/use-inline-calc";
 import { useAtom } from "jotai";
 
 // Custom hook for markdown formatter
@@ -67,11 +72,20 @@ type CommandItem = {
   perform: () => void;
 };
 
-const INTERFACE_IDS = new Set(["theme-toggle", "paper-mode", "editor-width", "font-family", "focus-mode"]);
+const INTERFACE_IDS = new Set([
+  "theme-toggle",
+  "paper-mode",
+  "editor-width",
+  "font-family",
+  "focus-mode",
+  "inline-calc",
+]);
 const OPERATION_IDS = new Set([
   "export-markdown",
   "format-document",
   "insert-github-issues",
+  "insert-date",
+  "insert-time",
   "open-tasks",
   "open-snapshots",
   "save-snapshot",
@@ -94,6 +108,7 @@ export const CommandMenu = ({
   const listRef = useRef<HTMLDivElement>(null);
   const [fontFamily, setFontFamily] = useAtom(fontFamilyAtom);
   const { focusMode, toggleFocusMode } = useFocusMode();
+  const { inlineCalcMode, toggleInlineCalc } = useInlineCalc();
 
   useEffect(() => {
     if (!open) {
@@ -134,6 +149,11 @@ export const CommandMenu = ({
 
   const toggleFocusModeThenClose = () => {
     toggleFocusMode();
+    onClose();
+  };
+
+  const toggleInlineCalcThenClose = () => {
+    toggleInlineCalc();
     onClose();
   };
 
@@ -242,34 +262,49 @@ export const CommandMenu = ({
     }
   };
 
-  const handleInsertGitHubIssues = async () => {
+  // The "input" userEvent annotation makes the persistence listener in
+  // use-markdown-editor.ts pick up the inserted text immediately.
+  const insertTextAtCursor = (text: string): boolean => {
     if (!editorView) {
       showToast("Editor not available", "error");
-      onClose();
-      return;
+      return false;
     }
+    const cursorPos = editorView.state.selection.main.head;
+    editorView.dispatch({
+      changes: { from: cursorPos, to: cursorPos, insert: text },
+      selection: { anchor: cursorPos + text.length },
+      annotations: Transaction.userEvent.of("input"),
+    });
+    return true;
+  };
+
+  const handleInsertGitHubIssues = async () => {
     try {
       const github_user_id = prompt("Enter GitHub User ID:");
       if (!github_user_id) {
-        onClose();
         return;
       }
       const issuesTaskList = await fetchGitHubIssuesTaskList(github_user_id);
-      const state = editorView.state;
-      const cursorPos = state.selection.main.head;
-
-      editorView.dispatch({
-        changes: { from: cursorPos, to: cursorPos, insert: issuesTaskList },
-        selection: { anchor: cursorPos + issuesTaskList.length },
-      });
-
-      showToast(`Inserted GitHub issues for ${github_user_id}`, "success");
+      if (insertTextAtCursor(issuesTaskList)) {
+        showToast(`Inserted GitHub issues for ${github_user_id}`, "success");
+      }
     } catch (error) {
       console.error("Error inserting GitHub issues:", error);
       showToast("Failed to insert GitHub issues", "error");
     } finally {
       onClose();
     }
+  };
+
+  const handleInsertDate = () => {
+    insertTextAtCursor(formatDateKey(new Date()));
+    onClose();
+  };
+
+  const handleInsertTime = () => {
+    const now = new Date();
+    insertTextAtCursor(`${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`);
+    onClose();
   };
 
   const goToGitHubRepo = () => {
@@ -348,6 +383,12 @@ export const CommandMenu = ({
       perform: toggleFocusModeThenClose,
     });
     list.push({
+      id: "inline-calc",
+      name: "Toggle inline calculator (Experimental)",
+      icon: <CalculatorIcon className="size-4" weight="light" />,
+      perform: toggleInlineCalcThenClose,
+    });
+    list.push({
       id: "export-markdown",
       name: "Export markdown",
       icon: <FileIcon className="size-4" weight="light" />,
@@ -370,6 +411,18 @@ export const CommandMenu = ({
         name: "Create GitHub issue list (Public Repos)",
         icon: <GithubLogoIcon className="size-4" weight="light" />,
         perform: handleInsertGitHubIssues,
+      });
+      list.push({
+        id: "insert-date",
+        name: "Insert current date",
+        icon: <CalendarBlankIcon className="size-4" weight="light" />,
+        perform: handleInsertDate,
+      });
+      list.push({
+        id: "insert-time",
+        name: "Insert current time",
+        icon: <ClockIcon className="size-4" weight="light" />,
+        perform: handleInsertTime,
       });
     }
 
@@ -490,6 +543,11 @@ export const CommandMenu = ({
                               {command.id === "focus-mode" && (
                                 <span className="ml-1.5 text-neutral-500 text-xs dark:text-neutral-400">
                                   ({focusMode})
+                                </span>
+                              )}
+                              {command.id === "inline-calc" && (
+                                <span className="ml-1.5 text-neutral-500 text-xs dark:text-neutral-400">
+                                  ({inlineCalcMode})
                                 </span>
                               )}
                             </span>

--- a/src/features/menu/system-menu.tsx
+++ b/src/features/menu/system-menu.tsx
@@ -29,6 +29,7 @@ import { taskStorage } from "../editor/tasks/task-storage";
 import { snapshotStorage } from "../snapshots/snapshot-storage";
 import { useTaskAutoFlush, type TaskAutoFlushMode } from "../../utils/hooks/use-task-auto-flush";
 import { useFocusMode, type FocusMode } from "../../utils/hooks/use-focus-mode";
+import { useInlineCalc, type InlineCalcMode } from "../../utils/hooks/use-inline-calc";
 import { useAtom, useAtomValue } from "jotai";
 
 const cx = (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(" ");
@@ -63,6 +64,10 @@ type MenuRowProps = {
   label: string;
   children?: ReactNode;
   icon?: ReactNode;
+  /** Extra qualifier rendered after the label in smaller, dimmed text. */
+  labelSuffix?: string;
+  /** Feature explanation shown as a tooltip while hovering the row. */
+  hint?: string;
   onClick?: () => void;
 };
 
@@ -108,9 +113,20 @@ const ValuePill = ({ children }: { children: ReactNode }) => (
   </span>
 );
 
-const MenuRowContent = ({ label, children, icon }: Omit<MenuRowProps, "onClick">) => (
+const MenuRowContent = ({ label, children, icon, labelSuffix, hint }: Omit<MenuRowProps, "onClick">) => (
   <>
-    <span className="min-w-0 truncate">{label}</span>
+    <span className="min-w-0 truncate">
+      {label}
+      {labelSuffix && <span className="ml-1 text-[10px] text-neutral-400 dark:text-neutral-500">{labelSuffix}</span>}
+      {hint && (
+        <span
+          role="tooltip"
+          className="pointer-events-none absolute bottom-full left-2 z-30 mb-1 w-52 whitespace-normal rounded-md bg-neutral-900 px-2.5 py-1.5 text-[11px] text-white leading-snug opacity-0 shadow-lg transition-opacity delay-150 duration-150 group-hover/hint:opacity-100 dark:bg-neutral-100 dark:text-neutral-900"
+        >
+          {hint}
+        </span>
+      )}
+    </span>
     {children ? (
       children
     ) : (
@@ -121,9 +137,9 @@ const MenuRowContent = ({ label, children, icon }: Omit<MenuRowProps, "onClick">
   </>
 );
 
-const StaticMenuRow = ({ label, children, icon }: Omit<MenuRowProps, "onClick">) => (
-  <div className={staticRowClassName}>
-    <MenuRowContent label={label} icon={icon}>
+const StaticMenuRow = ({ label, children, icon, labelSuffix, hint }: Omit<MenuRowProps, "onClick">) => (
+  <div className={cx(staticRowClassName, hint && "group/hint relative")}>
+    <MenuRowContent label={label} icon={icon} labelSuffix={labelSuffix} hint={hint}>
       {children}
     </MenuRowContent>
   </div>
@@ -245,6 +261,7 @@ export const SystemMenu = ({ onOpenHistoryModal, onRestoreEditorFocus }: SystemM
   const { snapshotCount } = useSnapshotCount(menuOpen);
   const { taskAutoFlushMode, setTaskAutoFlushMode } = useTaskAutoFlush();
   const { focusMode, setFocusMode } = useFocusMode();
+  const { inlineCalcMode, setInlineCalcMode } = useInlineCalc();
 
   const themeOptions: Array<SegmentOption<ColorTheme>> = [
     { value: COLOR_THEME.LIGHT, label: "Light", icon: <SunIcon className="size-4" weight="regular" /> },
@@ -274,6 +291,11 @@ export const SystemMenu = ({ onOpenHistoryModal, onRestoreEditorFocus }: SystemM
   ];
 
   const focusModeOptions: Array<SegmentOption<FocusMode>> = [
+    { value: "off", label: "Off" },
+    { value: "on", label: "On" },
+  ];
+
+  const inlineCalcOptions: Array<SegmentOption<InlineCalcMode>> = [
     { value: "off", label: "Off" },
     { value: "on", label: "On" },
   ];
@@ -401,6 +423,22 @@ export const SystemMenu = ({ onOpenHistoryModal, onRestoreEditorFocus }: SystemM
                   options={focusModeOptions}
                   onChange={(next) => {
                     setFocusMode(next);
+                    restoreEditorFocusSoon();
+                  }}
+                  variant="text"
+                />
+              </StaticMenuRow>
+              <StaticMenuRow
+                label="Calc"
+                labelSuffix="(Experimental)"
+                hint="Evaluates math as you type: 12 * 4, variables like price = 1200, and sum / average for the lines above. Click a result to copy it."
+              >
+                <SegmentedControl
+                  ariaLabel="Inline calculator"
+                  value={inlineCalcMode}
+                  options={inlineCalcOptions}
+                  onChange={(next) => {
+                    setInlineCalcMode(next);
                     restoreEditorFocusSoon();
                   }}
                   variant="text"

--- a/src/features/menu/system-menu.tsx
+++ b/src/features/menu/system-menu.tsx
@@ -121,7 +121,7 @@ const MenuRowContent = ({ label, children, icon, labelSuffix, hint }: Omit<MenuR
       {hint && (
         <span
           role="tooltip"
-          className="pointer-events-none absolute bottom-full left-2 z-30 mb-1 w-52 whitespace-normal rounded-md bg-neutral-900 px-2.5 py-1.5 text-[11px] text-white leading-snug opacity-0 shadow-lg transition-opacity delay-150 duration-150 group-hover/hint:opacity-100 dark:bg-neutral-100 dark:text-neutral-900"
+          className="pointer-events-none absolute bottom-full left-2 z-30 mb-1 w-52 whitespace-normal rounded-md bg-white px-2.5 py-1.5 text-[11px] text-neutral-700 leading-snug opacity-0 shadow-lg ring-1 ring-neutral-200 transition-opacity delay-150 duration-150 group-hover/hint:opacity-100 dark:bg-neutral-900 dark:text-neutral-300 dark:ring-white/10"
         >
           {hint}
         </span>

--- a/src/features/menu/system-menu.tsx
+++ b/src/features/menu/system-menu.tsx
@@ -35,7 +35,8 @@ import { useAtom, useAtomValue } from "jotai";
 const cx = (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(" ");
 
 const panelClassName =
-  "cosmos-menu-panel absolute bottom-full left-0 z-20 mb-2 w-[248px] max-w-[calc(100vw-1rem)] select-none overflow-hidden rounded-xl bg-white/95 p-2 text-[13px] text-neutral-950 shadow-xl backdrop-blur-xl focus:outline-none dark:bg-neutral-950/95 dark:text-neutral-50";
+  // No overflow-hidden: row hint tooltips extend past the panel's right edge.
+  "cosmos-menu-panel absolute bottom-full left-0 z-20 mb-2 w-[248px] max-w-[calc(100vw-1rem)] select-none rounded-xl bg-white/95 p-2 text-[13px] text-neutral-950 shadow-xl backdrop-blur-xl focus:outline-none dark:bg-neutral-950/95 dark:text-neutral-50";
 
 const rowBaseClassName =
   "flex min-h-11 w-full items-center justify-between gap-3 rounded-md px-3 text-left transition-[background-color,transform,color] duration-150 ease-out";
@@ -121,7 +122,7 @@ const MenuRowContent = ({ label, children, icon, labelSuffix, hint }: Omit<MenuR
       {hint && (
         <span
           role="tooltip"
-          className="pointer-events-none absolute bottom-full left-2 z-30 mb-1 w-52 whitespace-normal rounded-md bg-white px-2.5 py-1.5 text-[11px] text-neutral-700 leading-snug opacity-0 shadow-lg ring-1 ring-neutral-200 transition-opacity delay-150 duration-150 group-hover/hint:opacity-100 dark:bg-neutral-900 dark:text-neutral-300 dark:ring-white/10"
+          className="pointer-events-none absolute top-1/2 left-full z-30 ml-4 w-56 -translate-y-1/2 whitespace-normal rounded-md bg-white px-2.5 py-1.5 text-[11px] text-neutral-700 leading-snug opacity-0 shadow-lg ring-1 ring-neutral-200 transition-opacity delay-150 duration-150 group-hover/hint:opacity-100 dark:bg-neutral-900 dark:text-neutral-300 dark:ring-white/10"
         >
           {hint}
         </span>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,6 +9,7 @@ export const LOCAL_STORAGE_KEYS = {
   TOC_MODE: "ephe:toc-mode",
   TASK_AUTO_FLUSH_MODE: "ephe:task-auto-flush-mode",
   FOCUS_MODE: "ephe:focus-mode",
+  INLINE_CALC: "ephe:inline-calc",
   FONT_FAMILY: "ephe:font-family",
   CURSOR_COLOR: "ephe:cursor-color",
   CURSOR_POSITION: "ephe:cursor-position",

--- a/src/utils/hooks/use-inline-calc.ts
+++ b/src/utils/hooks/use-inline-calc.ts
@@ -1,0 +1,24 @@
+import { atomWithStorage } from "jotai/utils";
+import { LOCAL_STORAGE_KEYS } from "../constants";
+import { useAtom } from "jotai";
+
+export type InlineCalcMode = "off" | "on";
+
+export const inlineCalcAtom = atomWithStorage<InlineCalcMode>(LOCAL_STORAGE_KEYS.INLINE_CALC, "on");
+
+export const useInlineCalc = () => {
+  const [inlineCalcMode, setInlineCalcMode] = useAtom(inlineCalcAtom);
+
+  const toggleInlineCalc = () => {
+    const next: InlineCalcMode = inlineCalcMode === "on" ? "off" : "on";
+    setInlineCalcMode(next);
+    return next;
+  };
+
+  return {
+    inlineCalcMode,
+    isInlineCalcEnabled: inlineCalcMode === "on",
+    setInlineCalcMode,
+    toggleInlineCalc,
+  };
+};


### PR DESCRIPTION
## Summary

Brings Antinote-inspired features to Ephe.

### Inline calculator (Experimental)

A new CodeMirror extension (`src/features/editor/codemirror/calc/`) that evaluates math as you type and renders results as click-to-copy widgets at line ends:

- **Expressions** — `12 * 4` shows `= 48`; supports `+ - * / % ^`, parens, functions (`sqrt`, `round`, `min`, `max`, …), constants (`pi`, `e`), currency symbols, and comma-grouped numbers (`$1,200 * 3`)
- **Reactive variables** — `price = 1200` defines a variable usable in lines below
- **Aggregates** — `sum` / `total` / `avg` / `average` on its own line totals the blank-line-delimited block above, including plain-text amounts like `coffee 4.50`
- **False-positive guards** — dates (`2026-07-06`), clock times (`12:30`), and fenced code blocks are skipped; a trailing `=` forces a result
- Safety: hand-rolled recursive-descent parser, no `eval()`

Toggleable via System menu (**Calc (Experimental)**, with an explanatory hover tooltip) and Cmd+K; persisted as `ephe:inline-calc` (default on), wired through a compartment like focus mode.

### Insert date / time commands

Cmd+K gains **Insert current date** (`YYYY-MM-DD`, reusing `formatDateKey`) and **Insert current time** (`HH:MM`). All cursor inserts (including GitHub issues) now go through one `userEvent: input`-annotated dispatch so inserted text persists immediately.

## Testing

- Unit tests for the expression parser and document evaluator (29 cases), browser tests for the extension (Playwright)
- Verified end-to-end in the running app: live results, variables + sum, widget click-to-copy, System menu / Cmd+K toggles, date/time insertion, persistence across reload, light/dark tooltip rendering