### PR TITLE
fix: persist completed tasks when toggled via mouse click

### DIFF
--- a/src/features/editor/codemirror/tasklist/task-close.browser.test.ts
+++ b/src/features/editor/codemirror/tasklist/task-close.browser.test.ts
@@ -1,0 +1,59 @@
+import { EditorView } from "@codemirror/view";
+import { EditorState } from "@codemirror/state";
+import { test, expect, describe, vi, afterEach } from "vitest";
+import { taskMouseInteraction, type TaskHandler } from "./task-close";
+
+const createView = (text: string, taskHandler: TaskHandler): EditorView => {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  const state = EditorState.create({
+    doc: text,
+    extensions: [taskMouseInteraction(taskHandler)],
+  });
+  return new EditorView({ state, parent });
+};
+
+const clickAt = (view: EditorView, pos: number) => {
+  const coords = view.coordsAtPos(pos);
+  if (!coords) throw new Error(`no coords at pos ${pos}`);
+  const x = (coords.left + coords.right) / 2;
+  const y = (coords.top + coords.bottom) / 2;
+  view.dom.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: x, clientY: y, button: 0 }));
+};
+
+describe("taskMouseInteraction", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("clicking an open checkbox toggles it and calls onTaskClosed", () => {
+    const onTaskClosed = vi.fn();
+    const onTaskOpen = vi.fn();
+    const view = createView("- [ ] Buy milk", { onTaskClosed, onTaskOpen });
+
+    clickAt(view, 3);
+
+    expect(view.state.doc.toString()).toBe("- [x] Buy milk");
+    expect(onTaskOpen).not.toHaveBeenCalled();
+    expect(onTaskClosed).toHaveBeenCalledTimes(1);
+    expect(onTaskClosed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskContent: "Buy milk",
+        originalLine: "- [ ] Buy milk",
+      }),
+    );
+  });
+
+  test("clicking a checked checkbox toggles it and calls onTaskOpen", () => {
+    const onTaskClosed = vi.fn();
+    const onTaskOpen = vi.fn();
+    const view = createView("- [x] Buy milk", { onTaskClosed, onTaskOpen });
+
+    clickAt(view, 3);
+
+    expect(view.state.doc.toString()).toBe("- [ ] Buy milk");
+    expect(onTaskClosed).not.toHaveBeenCalled();
+    expect(onTaskOpen).toHaveBeenCalledTimes(1);
+    expect(onTaskOpen).toHaveBeenCalledWith("Buy milk");
+  });
+});

--- a/src/features/editor/codemirror/tasklist/task-close.ts
+++ b/src/features/editor/codemirror/tasklist/task-close.ts
@@ -8,6 +8,7 @@ import {
 } from "@codemirror/view";
 import { StateEffect, StateField, RangeSetBuilder } from "@codemirror/state";
 import type { OnTaskClosed } from ".";
+import { findTaskSection } from "./task-section-utils";
 
 export type TaskHandler = {
   onTaskClosed: ({ taskContent, originalLine, section }: OnTaskClosed) => void;
@@ -238,6 +239,9 @@ export const taskMouseInteraction = (taskHandler?: TaskHandler) => {
         event.preventDefault();
         const newChar = task.checked ? " " : "x";
 
+        const line = this.view.state.doc.lineAt(task.from);
+        const taskContent = line.text.substring(task.to - line.from).trim();
+
         this.view.dispatch({
           changes: {
             from: task.contentPos,
@@ -246,6 +250,18 @@ export const taskMouseInteraction = (taskHandler?: TaskHandler) => {
           },
           userEvent: "input.toggleTask",
         });
+
+        if (newChar === "x") {
+          this.taskHandler?.onTaskClosed({
+            taskContent,
+            originalLine: line.text,
+            section: findTaskSection(this.view, line.number),
+            pos: task.from,
+            view: this.view,
+          });
+        } else {
+          this.taskHandler?.onTaskOpen(taskContent);
+        }
       }
     },
   );


### PR DESCRIPTION
## Summary
- PR #107 removed the background task-close scanner, which used to call `taskHandler.onTaskClosed`/`onTaskOpen` whenever a task's checked state changed.
- That removal never wired an equivalent call into `taskMouseInteraction`'s `handleMouseDown` — the only remaining place a task's checkbox actually toggles — so `taskHandler` was stored but never invoked.
- Net effect: checking off a task in the editor never wrote anything to `taskStorage`, so the History modal's "Tasks" tab stayed stuck/empty no matter what was completed.
- Fix: call `taskHandler.onTaskClosed`/`onTaskOpen` directly from `handleMouseDown`, using the task's line/content already available at click time (before the checkbox character is swapped).

## Test plan
- [x] pnpm exec tsc --noEmit
- [x] pnpm lint (biome + eslint)
- [x] pnpm test (154 tests passing, incl. 2 new browser tests simulating a real mouse click to verify onTaskClosed/onTaskOpen fire correctly)
- [ ] Manual check: complete a task in the editor, open History → Tasks, confirm it appears