### PR TITLE
fix: align paper grid with the editor's text

### DIFF
--- a/src/features/editor/codemirror/paper-background.ts
+++ b/src/features/editor/codemirror/paper-background.ts
@@ -1,0 +1,88 @@
+import type { PaperMode } from "../../../utils/hooks/use-paper-mode";
+
+/**
+ * The metrics the editor lays its text out with.
+ *
+ * The paper pattern is derived from these rather than chosen independently, so
+ * a ruling can never drift away from the text: every cell is a whole fraction
+ * of a line box, and the pattern's origin is the top-left corner of the first
+ * line.
+ */
+export const EDITOR_LAYOUT = {
+  fontSizePx: 16,
+  // A length rather than a ratio, applied to every line including headings, so
+  // a line box is always exactly one row of paper. A ratio would make headings
+  // taller than a row and push every line after them off the ruling.
+  lineHeightPx: 26,
+  paddingXPx: 20,
+  paddingYPx: 60,
+  maxWidthPx: 680,
+} as const;
+
+type Pattern = {
+  cellPx: number;
+  /** Distance from the tile's origin to the ink it draws. */
+  inkOffsetPx: number;
+  color: { light: string; dark: string };
+  image: (color: string) => string;
+};
+
+const PATTERNS: Record<Exclude<PaperMode, "normal">, Pattern> = {
+  graph: {
+    // Half a line box: a ruling on every line boundary plus one through the
+    // middle, which keeps the fine squares graph paper is supposed to have.
+    cellPx: EDITOR_LAYOUT.lineHeightPx / 2,
+    // Gradients start their ruling at the tile's edge.
+    inkOffsetPx: 0,
+    color: { light: "rgba(210, 210, 210, 0.3)", dark: "rgba(80, 80, 80, 0.3)" },
+    image: (color) =>
+      `linear-gradient(${color} 1px, transparent 1px), linear-gradient(to right, ${color} 1px, transparent 1px)`,
+  },
+  dots: {
+    cellPx: EDITOR_LAYOUT.lineHeightPx,
+    // A radial gradient centres its dot in the tile.
+    inkOffsetPx: EDITOR_LAYOUT.lineHeightPx / 2,
+    color: { light: "rgba(210, 210, 210, 0.5)", dark: "rgba(80, 80, 80, 0.5)" },
+    image: (color) => `radial-gradient(${color} 1px, transparent 1px)`,
+  },
+};
+
+/**
+ * Places the pattern's ink on the top-left corner of the first line of text.
+ *
+ * `background-position` percentages resolve against (area - tile) instead of
+ * the area alone, so a bare `50%` lands a tile half a cell left of centre; the
+ * `cellPx / 2` term puts it back. `max()` covers viewports narrower than the
+ * text column, where the text stops being centred and sits on its padding.
+ */
+const patternOrigin = (pattern: Pattern, isWideMode: boolean): string => {
+  const { maxWidthPx, paddingXPx, paddingYPx } = EDITOR_LAYOUT;
+  const top = `${paddingYPx - pattern.inkOffsetPx}px`;
+  const left = `${paddingXPx - pattern.inkOffsetPx}px`;
+  if (isWideMode) return `${left} ${top}`;
+  const fromCenter = maxWidthPx / 2 - paddingXPx - pattern.cellPx / 2 + pattern.inkOffsetPx;
+  return `max(${left}, calc(50% - ${fromCenter}px)) ${top}`;
+};
+
+/**
+ * The paper for the editor's scroller. The page behind it only carries the
+ * paper's colour; the pattern lives here because this is the only element that
+ * knows where the text actually is.
+ */
+export const paperBackgroundStyle = (
+  paperMode: PaperMode,
+  isDarkMode: boolean,
+  isWideMode: boolean,
+): Record<string, string> => {
+  if (paperMode === "normal") return {};
+
+  const pattern = PATTERNS[paperMode];
+  return {
+    backgroundImage: pattern.image(isDarkMode ? pattern.color.dark : pattern.color.light),
+    backgroundSize: `${pattern.cellPx}px ${pattern.cellPx}px`,
+    backgroundPosition: patternOrigin(pattern, isWideMode),
+    // Anchors the pattern to the text instead of the viewport, so the two stay
+    // aligned while scrolling.
+    backgroundAttachment: "local",
+  };
+};

--- a/src/features/editor/codemirror/use-editor-theme.ts
+++ b/src/features/editor/codemirror/use-editor-theme.ts
@@ -3,11 +3,19 @@ import { EditorView } from "@codemirror/view";
 import { tags } from "@lezer/highlight";
 import { useMemo } from "react";
 import { getCursorColor, type CursorColor } from "../../../utils/hooks/use-cursor-color";
+import type { PaperMode } from "../../../utils/hooks/use-paper-mode";
+import { EDITOR_LAYOUT, paperBackgroundStyle } from "./paper-background";
 
 /**
- * Manages the CodeMirror theme and highlight style based on dark mode, editor width, and font family.
+ * Manages the CodeMirror theme and highlight style based on dark mode, editor width, font family, and paper mode.
  */
-export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFamily: string, cursorColor: CursorColor) => {
+export const useEditorTheme = (
+  isDarkMode: boolean,
+  isWideMode: boolean,
+  fontFamily: string,
+  cursorColor: CursorColor,
+  paperMode: PaperMode,
+) => {
   return useMemo(() => {
     const COLORS = isDarkMode ? EPHE_COLORS.dark : EPHE_COLORS.light;
     const CODE_SYNTAX_HIGHLIGHT = isDarkMode ? SYNTAX_HIGHLIGHT_STYLES.dark : SYNTAX_HIGHLIGHT_STYLES.light;
@@ -22,22 +30,25 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
         tag: tags.heading1,
         color: COLORS.heading,
         fontSize: "1.2em",
+        ...STAYS_WITHIN_ONE_ROW,
       },
       {
         tag: tags.heading2,
         color: COLORS.heading,
         fontSize: "1.2em",
+        ...STAYS_WITHIN_ONE_ROW,
       },
       {
         tag: tags.heading3,
         color: COLORS.heading,
         fontSize: "1.1em",
+        ...STAYS_WITHIN_ONE_ROW,
       },
       { tag: tags.emphasis, color: COLORS.emphasis, fontStyle: "italic" },
       { tag: tags.strong, color: COLORS.emphasis },
       { tag: tags.link, color: COLORS.string, textDecoration: "underline" },
       { tag: tags.url, color: COLORS.string, textDecoration: "underline" },
-      { tag: tags.monospace, color: COLORS.constant, fontFamily: "monospace" },
+      { tag: tags.monospace, color: COLORS.constant, fontFamily: "monospace", ...STAYS_WITHIN_ONE_ROW },
     ]);
 
     const theme = {
@@ -49,10 +60,10 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
       },
       ".cm-content": {
         fontFamily: fontFamily,
-        fontSize: "16px",
-        padding: "60px 20px",
-        lineHeight: "1.6",
-        maxWidth: isWideMode ? "100%" : "680px",
+        fontSize: `${EDITOR_LAYOUT.fontSizePx}px`,
+        padding: `${EDITOR_LAYOUT.paddingYPx}px ${EDITOR_LAYOUT.paddingXPx}px`,
+        lineHeight: `${EDITOR_LAYOUT.lineHeightPx}px`,
+        maxWidth: isWideMode ? "100%" : `${EDITOR_LAYOUT.maxWidthPx}px`,
         margin: "0 auto",
         caretColor: "transparent",
         fontFeatureSettings: fontFamily.includes("Mynerve") ? '"calt" off, "salt" off' : "normal",
@@ -97,7 +108,7 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
       },
       ".cm-scroller": {
         fontFamily: fontFamily,
-        background: "transparent",
+        ...paperBackgroundStyle(paperMode, isDarkMode, isWideMode),
         fontFeatureSettings: fontFamily.includes("Mynerve")
           ? '"calt" off, "salt" off, "liga" off, "dlig" off, "clig" off'
           : "normal",
@@ -119,8 +130,17 @@ export const useEditorTheme = (isDarkMode: boolean, isWideMode: boolean, fontFam
       editorTheme: EditorView.theme(theme),
       editorHighlightStyle: syntaxHighlighting(epheHighlightStyle, { fallback: true }),
     };
-  }, [isDarkMode, isWideMode, fontFamily, cursorColor]);
+  }, [isDarkMode, isWideMode, fontFamily, cursorColor, paperMode]);
 };
+
+/**
+ * Inline text that changes the font's metrics — a larger size, another family —
+ * would otherwise stretch its line past one row of paper: the browser aligns
+ * that box with the line's strut on their shared baseline, so the taller box's
+ * ascender sticks out above it. Sizing the inline box to its own glyphs keeps
+ * it inside the strut, and every line stays exactly one row tall.
+ */
+const STAYS_WITHIN_ONE_ROW = { lineHeight: "1" } as const;
 
 const EPHE_COLORS = {
   light: {

--- a/src/features/editor/codemirror/use-markdown-editor.ts
+++ b/src/features/editor/codemirror/use-markdown-editor.ts
@@ -25,6 +25,7 @@ import { cursorColorAtom, resolveCursorColor } from "../../../utils/hooks/use-cu
 import { customCursorLayer } from "./cursor-layer";
 import { useFocusMode } from "../../../utils/hooks/use-focus-mode";
 import { focusModeExtension } from "./focus-mode";
+import { usePaperMode } from "../../../utils/hooks/use-paper-mode";
 
 const useMarkdownFormatter = () => {
   const ref = useRef<DprintMarkdownFormatter | null>(null);
@@ -82,8 +83,15 @@ export const useMarkdownEditor = (
   const { isWideMode } = useEditorWidth();
   const currentFontValue = useAtomValue(currentFontValueAtom);
   const cursorColor = resolveCursorColor(useAtomValue(cursorColorAtom));
+  const { paperMode } = usePaperMode();
 
-  const { editorTheme, editorHighlightStyle } = useEditorTheme(isDarkMode, isWideMode, currentFontValue, cursorColor);
+  const { editorTheme, editorHighlightStyle } = useEditorTheme(
+    isDarkMode,
+    isWideMode,
+    currentFontValue,
+    cursorColor,
+    paperMode,
+  );
   const { isMobile } = useMobileDetector();
 
   const { isFocusMode } = useFocusMode();

--- a/src/features/picture-in-picture/use-document-picture-in-picture.ts
+++ b/src/features/picture-in-picture/use-document-picture-in-picture.ts
@@ -2,6 +2,7 @@ import type { EditorView } from "@codemirror/view";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from "react";
 import { showToast } from "../../utils/components/toast";
 import { getDocumentPictureInPicture, preparePictureInPictureDocument } from "./document-picture-in-picture";
+import { PAPER_SURFACE_CLASS } from "../../utils/hooks/use-paper-mode";
 
 const PICTURE_IN_PICTURE_SIZE = {
   width: 420,
@@ -19,14 +20,12 @@ type UseDocumentPictureInPictureOptions = {
   editorSlotRef: RefObject<HTMLDivElement | null>;
   editorSurface: HTMLDivElement;
   getEditorView: () => EditorView | null;
-  paperModeClass: string;
 };
 
 export const useDocumentPictureInPicture = ({
   editorSlotRef,
   editorSurface,
   getEditorView,
-  paperModeClass,
 }: UseDocumentPictureInPictureOptions) => {
   const [isPictureInPicture, setIsPictureInPicture] = useState(false);
   const sessionRef = useRef<PictureInPictureSession | null>(null);
@@ -37,21 +36,15 @@ export const useDocumentPictureInPicture = ({
     getEditorViewRef.current = getEditorView;
   }, [getEditorView]);
 
+  // The paper's grid or dots ride along with the editor's own theme, so only
+  // the light/dark class on the root has to be mirrored by hand.
   const syncAppearance = useCallback(() => {
     const session = sessionRef.current;
     if (!session) return;
 
     session.window.document.documentElement.className = document.documentElement.className;
-    session.root.className = `h-screen overflow-hidden antialiased ${paperModeClass}`;
-  }, [paperModeClass]);
-
-  // The theme observer must always see the latest paperModeClass, not the one
-  // captured when the picture-in-picture window was opened.
-  const syncAppearanceRef = useRef(syncAppearance);
-  useEffect(() => {
-    syncAppearanceRef.current = syncAppearance;
-    syncAppearance();
-  }, [syncAppearance]);
+    session.root.className = `h-screen overflow-hidden antialiased ${PAPER_SURFACE_CLASS}`;
+  }, []);
 
   const attachEditorTo = useCallback(
     (container: HTMLElement, root: Document) => {
@@ -116,7 +109,7 @@ export const useDocumentPictureInPicture = ({
       };
       targetWindow.addEventListener("focus", focusEditor);
 
-      const themeObserver = new MutationObserver(() => syncAppearanceRef.current());
+      const themeObserver = new MutationObserver(syncAppearance);
       themeObserver.observe(document.documentElement, {
         attributes: true,
         attributeFilter: ["class"],
@@ -132,7 +125,7 @@ export const useDocumentPictureInPicture = ({
       };
 
       attachEditorTo(pictureInPictureRoot, targetWindow.document);
-      syncAppearanceRef.current();
+      syncAppearance();
       focusEditor();
 
       targetWindow.addEventListener(
@@ -159,7 +152,7 @@ export const useDocumentPictureInPicture = ({
     } finally {
       isOpeningRef.current = false;
     }
-  }, [attachEditorTo, returnEditorToMainWindow]);
+  }, [attachEditorTo, returnEditorToMainWindow, syncAppearance]);
 
   useLayoutEffect(() => {
     return () => {

--- a/src/globals.css
+++ b/src/globals.css
@@ -48,44 +48,27 @@ body {
   }
 }
 
-/* Paper Mode: Graph Paper (Light Mode) */
-.bg-graph-paper {
-  background-image:
-    linear-gradient(rgba(210, 210, 210, 0.3) 1px, transparent 1px),
-    linear-gradient(to right, rgba(210, 210, 210, 0.3) 1px, transparent 1px);
-  background-size: 12px 12px;
-  background-color: #fff;
-  background-position: -14px 14px;
-}
-
-/* Paper Mode: Graph Paper (Dark Mode) */
-.dark .bg-graph-paper {
-  background-image:
-    linear-gradient(rgba(80, 80, 80, 0.3) 1px, transparent 1px),
-    linear-gradient(to right, rgba(80, 80, 80, 0.3) 1px, transparent 1px);
-  background-size: 12px 12px;
-  background-color: #0d1117;
-  background-position: -14px 14px;
-}
-
-/* Paper Mode: Normal (Light Mode) */
-.bg-normal-paper {
+/*
+ * The colour of the sheet the editor writes on. Graph and dots rulings are
+ * painted by the editor itself (src/features/editor/codemirror/paper-background.ts)
+ * so they can line up with the text; only the colour belongs to the page.
+ */
+.bg-paper {
   background-color: #fff;
 }
 
-/* Paper Mode: Normal (Dark Mode) */
-.dark .bg-normal-paper {
+.dark .bg-paper {
   background-color: #0d1117;
 }
 
-/* Paper Mode: Dots (Light Mode) */
+/* Dots for the landing page, which has no text to align to (Light Mode) */
 .bg-dots-paper {
   background-image: radial-gradient(rgba(210, 210, 210, 0.5) 1px, transparent 1px);
   background-size: 24px 24px;
   background-color: #fff;
 }
 
-/* Paper Mode: Dots (Dark Mode) */
+/* Dots for the landing page (Dark Mode) */
 .dark .bg-dots-paper {
   background-image: radial-gradient(rgba(80, 80, 80, 0.5) 1px, transparent 1px);
   background-size: 16px 16px;

--- a/src/page/editor-page.tsx
+++ b/src/page/editor-page.tsx
@@ -19,10 +19,9 @@ import { Footer, FooterButton } from "../utils/components/footer";
 import { useCommandK } from "../utils/hooks/use-command-k";
 import { useEditorMode } from "../utils/hooks/use-editor-mode";
 import { useMobileDetector } from "../utils/hooks/use-mobile-detector";
-import { usePaperMode } from "../utils/hooks/use-paper-mode";
+import { PAPER_SURFACE_CLASS } from "../utils/hooks/use-paper-mode";
 
 export const EditorPage = () => {
-  const { paperModeClass } = usePaperMode();
   const { editorMode } = useEditorMode();
   const [historyModalOpen, setHistoryModalOpen] = useState(false);
   const [historyModalTabIndex, setHistoryModalTabIndex] = useState(0);
@@ -57,7 +56,6 @@ export const EditorPage = () => {
       editorSlotRef,
       editorSurface,
       getEditorView,
-      paperModeClass,
     });
 
   const restoreEditorFocus = useCallback(() => {
@@ -98,7 +96,7 @@ export const EditorPage = () => {
 
   return (
     <LazyMotion features={domAnimation} strict>
-      <div className={`flex h-screen flex-col overflow-hidden antialiased ${paperModeClass}`}>
+      <div className={`flex h-screen flex-col overflow-hidden antialiased ${PAPER_SURFACE_CLASS}`}>
         <div ref={editorSlotRef} className="relative flex flex-1 overflow-hidden">
           {createPortal(
             editorMode === "multi" ? (

--- a/src/utils/hooks/use-paper-mode.ts
+++ b/src/utils/hooks/use-paper-mode.ts
@@ -4,11 +4,12 @@ import { useAtom } from "jotai";
 
 export type PaperMode = "normal" | "graph" | "dots";
 
-const PAPER_MODE_CLASSES = {
-  normal: "bg-normal-paper",
-  graph: "bg-graph-paper",
-  dots: "bg-dots-paper",
-} as const;
+/**
+ * The colour of the sheet. Its grid or dots are painted by the editor itself
+ * (see `paper-background.ts`), which is the only place that knows where the
+ * text sits, so a mode does not get a class of its own here.
+ */
+export const PAPER_SURFACE_CLASS = "bg-paper";
 
 const modes = ["normal", "graph", "dots"] as const;
 const paperModeAtom = atomWithStorage<PaperMode>(LOCAL_STORAGE_KEYS.PAPER_MODE, "normal");
@@ -25,7 +26,6 @@ export const usePaperMode = () => {
 
   return {
     paperMode,
-    paperModeClass: PAPER_MODE_CLASSES[paperMode],
     cyclePaperMode,
     setPaperMode,
   };


### PR DESCRIPTION
背景の grid / dots が入力されたテキストのサイズも位置も参照していなかったため、紙と文字がずれて見えていた問題を直します。

## 原因

1. パターンがページ最上位の全画面 div にあり、`background-size: 12px` / `background-position: -14px 14px` というテキストと無関係な固定値だった
2. 行の高さが `16px × 1.6 = 25.6px` の小数で、さらに見出しは `1.2em` により行箱が 27px になるため、見出しより後の行が 1px ずつずれていった
3. 背景がページ側にあるので、スクロールするとテキストだけが動いて背景は動かなかった

## 変更

- `paper-background.ts` を追加し、行高・パディング・カラム幅を単一の出典 `EDITOR_LAYOUT` にまとめて、そこからパターンを導出。セルは graph = 13px（行高の半分）、dots = 26px（行高そのもの）、原点は 1 行目の左上
- パターンを `.cm-scroller` に移動し `background-attachment: local` を指定。テキストと一緒にスクロールするので、どこまで送っても一致し続ける
- 行の高さを比率ではなく `26px` の実寸に変更。フォントサイズを変えるインライン（見出し・インラインコード）には `line-height: 1` を付け、行箱が 1 行分を超えないようにする
- ページ側の `.bg-paper` は紙の色だけを持つ。ランディングページのドットは揃える対象のテキストがないため従来どおり
- 紙のクラスが可変でなくなったことで不要になった PiP 側の ref 経由の間接参照を削除

見た目の変更として、見出しの行間が本文と同じ 1 行分になります。

## 検証

すべて Playwright による実測です。

- **原点**: dots / graph × 幅 420〜1200 × normal / wide × light / dark の 40 構成で、CSS の式が DOM 実測のテキスト原点とピクセル一致
- **スクロール**: タイル幅の倍数でない 17px のスクロール後のスクリーンショットが、17px 補正したクリップとバイト単位で一致（文字と紙が完全に一緒に動く）
- **行のグリッド**: 見出し・太字・斜体・インラインコード・リンク・タスク・折り返しを含む文書で、全行が 60px 起点の 26px の倍数（折り返し行は 52px）
- **フォント**: 選択可能な 4 フォント（iA Writer Mono / Monospace / IBM Plex Mono / Mynerve）すべてで全行 26px。見出し 3 は Monospace でのみ 27px になるため `line-height: 1` が必要と確認
- **モード切替**: dots → normal → graph をコマンドメニューから切り替え、normal で `background-image: none`（古いパターンが残らない）

`tsc` / `biome lint` / `biome format` / 単体テスト 154 件パス。e2e は `closes Picture-in-Picture when leaving the editor page` が失敗しますが、これは変更前の main でも同じく失敗する既存の失敗です（テストが `Ephe v<version>` のリンクを探しているが、d4d8f59 で version 表示が削除済み）。

https://claude.ai/code/session_01KVDhxHAJAUEgKQKBYV2EEE